### PR TITLE
[codex] Add SearchCollectionView core

### DIFF
--- a/docs/superpowers/plans/2026-04-25-search-collection-view-core.md
+++ b/docs/superpowers/plans/2026-04-25-search-collection-view-core.md
@@ -1,0 +1,550 @@
+# SearchCollectionView Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #586: the minimal `<search-collection-view>` custom element host, structure mounting, item rendering, item id validation, and core render/error events.
+
+**Architecture:** Add a focused `src/components/searchCollectionView/` module that exports the element class, registration helper, and public core types. The element owns only reusable collection rendering concerns for #586; selection, actions, view modes, search, and CardList migration stay out of scope.
+
+**Tech Stack:** TypeScript, Web Components, Vite, Vitest, happy-dom for DOM unit tests.
+
+---
+
+## File Structure
+
+- Create `src/components/searchCollectionView/types.ts`
+  - Public core types for #586: item, id resolver, renderer, render context, structure renderer, error detail, render-complete detail.
+- Create `src/components/searchCollectionView/SearchCollectionViewElement.ts`
+  - Custom element class, property setters/getters, structure lifecycle, item id validation, item rendering, `render-complete`, and `component-error`.
+- Create `src/components/searchCollectionView/index.ts`
+  - Re-export types/class and register the custom element exactly once.
+- Modify `src/components/index.ts` only if an existing component barrel exists. If no barrel exists, do not create unrelated exports.
+- Modify `src/index.ts`
+  - Import `@/components/searchCollectionView` so the custom element is registered in the app bundle.
+- Modify `package.json`
+  - Add `happy-dom` as a dev dependency if not already present.
+- Modify `vite.config.ts`
+  - Configure Vitest to use `happy-dom` for tests under `tests/vitest/unit/components/**/*.spec.ts`.
+- Create `tests/vitest/unit/components/searchCollectionView/core.spec.ts`
+  - DOM unit tests for #586 acceptance criteria.
+
+## Boundary
+
+This plan must not implement:
+
+- `selectedItemIds`, `setSelectedItemIds()`, `selectionAttribute`, `item-action`, or `selection-change` from #593.
+- `ViewModePlugin`, mode registration, active mode lifecycle, or styles from #587.
+- Search model, Search UI, hidden state, or search events from #588/#594.
+- CardList adapter or deck editor integration from #589/#590.
+
+## Task 1: Add DOM Test Environment
+
+**Files:**
+- Modify: `package.json`
+- Modify: `vite.config.ts`
+- Create: `tests/vitest/unit/components/searchCollectionView/core.spec.ts`
+
+- [ ] **Step 1: Add the first failing DOM test**
+
+Create `tests/vitest/unit/components/searchCollectionView/core.spec.ts`:
+
+```ts
+import { afterEach, describe, expect, it } from 'vitest';
+import { SearchCollectionViewElement } from '@/components/searchCollectionView';
+
+describe('SearchCollectionViewElement core rendering', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders item elements from plain object data and an element renderer', () => {
+    const view = new SearchCollectionViewElement();
+    view.renderer = (item, context) => {
+      const row = document.createElement('article');
+      row.className = 'row';
+      row.textContent = `${context.itemId}:${String(item.name)}`;
+      return row;
+    };
+
+    view.items = [
+      { id: 1, name: 'Alpha' },
+      { id: 2, name: 'Beta' },
+    ];
+    document.body.append(view);
+
+    const rows = [...view.querySelectorAll<HTMLElement>('.row')];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.dataset.itemId)).toEqual(['1', '2']);
+    expect(rows.map((row) => row.textContent)).toEqual(['1:Alpha', '2:Beta']);
+    expect(view.querySelector('.scv__items')).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: fail because `@/components/searchCollectionView` does not exist, or because DOM environment is missing.
+
+- [ ] **Step 3: Add happy-dom and Vitest environment config**
+
+Install:
+
+```bash
+npm install --save-dev happy-dom
+```
+
+Update `vite.config.ts` test config:
+
+```ts
+      environment: 'happy-dom',
+```
+
+Place `environment` inside the existing `test` object. This project currently has only Node-safe utility tests plus the new DOM component tests, so using `happy-dom` for the Vitest project keeps the setup simple.
+
+- [ ] **Step 4: Run the test again**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: fail only because `@/components/searchCollectionView` does not exist.
+
+## Task 2: Add Public Types and Minimal Element
+
+**Files:**
+- Create: `src/components/searchCollectionView/types.ts`
+- Create: `src/components/searchCollectionView/SearchCollectionViewElement.ts`
+- Create: `src/components/searchCollectionView/index.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add public core types**
+
+Create `src/components/searchCollectionView/types.ts`:
+
+```ts
+export type SearchCollectionItem = Record<string, unknown> & {
+  id?: string | number;
+};
+
+export type SearchCollectionItemIdResolver<TItem extends SearchCollectionItem> = (
+  item: TItem,
+  index: number,
+) => string | number;
+
+export interface SearchCollectionRenderContext<TItem extends SearchCollectionItem> {
+  itemId: string;
+  index: number;
+  selected: boolean;
+  mode: string;
+  emitAction(action: string, detail?: Record<string, unknown>): void;
+}
+
+export type SearchCollectionRenderer<TItem extends SearchCollectionItem> = (
+  item: TItem,
+  context: SearchCollectionRenderContext<TItem>,
+) => Element | DocumentFragment;
+
+export interface SearchCollectionStructure {
+  root: HTMLElement;
+  modeRoot?: HTMLElement;
+  itemsRoot: HTMLElement;
+  toolbarRoot?: HTMLElement;
+}
+
+export type SearchCollectionStructureRenderer = () => SearchCollectionStructure;
+
+export interface SearchCollectionErrorDetail {
+  code:
+    | 'missing-item-id'
+    | 'duplicate-item-id'
+    | 'invalid-structure'
+    | 'renderer-error';
+  message: string;
+  cause?: unknown;
+  itemId?: string;
+  mode?: string;
+}
+
+export interface SearchCollectionRenderCompleteDetail {
+  itemIds: string[];
+}
+```
+
+- [ ] **Step 2: Add minimal element implementation**
+
+Create `src/components/searchCollectionView/SearchCollectionViewElement.ts` with enough code to mount default structure, render element results, normalize `item.id`, and dispatch `render-complete`.
+
+- [ ] **Step 3: Add the barrel and registration helper**
+
+Create `src/components/searchCollectionView/index.ts`:
+
+```ts
+export * from './types';
+export { SearchCollectionViewElement, registerSearchCollectionViewElement } from './SearchCollectionViewElement';
+
+registerSearchCollectionViewElement();
+```
+
+- [ ] **Step 4: Register in app entrypoint**
+
+Modify `src/index.ts`:
+
+```ts
+import '@/components/searchCollectionView';
+import '@/global';
+import '@/core';
+import '@/start';
+```
+
+- [ ] **Step 5: Run the first test to verify GREEN**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: the first test passes.
+
+## Task 3: Validate Item IDs Without Mutating Existing DOM
+
+**Files:**
+- Modify: `tests/vitest/unit/components/searchCollectionView/core.spec.ts`
+- Modify: `src/components/searchCollectionView/SearchCollectionViewElement.ts`
+
+- [ ] **Step 1: Add RED tests for `getItemId`, missing id, and duplicate id**
+
+Append tests that verify:
+
+```ts
+it('uses getItemId when item.id is absent', () => {
+  const view = new SearchCollectionViewElement<{ key: number; name: string }>();
+  view.getItemId = (item) => item.key;
+  view.renderer = (item) => {
+    const row = document.createElement('article');
+    row.textContent = item.name;
+    return row;
+  };
+
+  view.items = [{ key: 42, name: 'No id' }];
+  document.body.append(view);
+
+  expect(view.querySelector<HTMLElement>('article')?.dataset.itemId).toBe('42');
+});
+
+it('keeps previous rendered items when an item id is missing', () => {
+  const view = new SearchCollectionViewElement();
+  const errors: CustomEvent[] = [];
+  view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+  view.renderer = (item) => {
+    const row = document.createElement('article');
+    row.textContent = String(item.name);
+    return row;
+  };
+  view.items = [{ id: 1, name: 'Existing' }];
+  document.body.append(view);
+
+  view.items = [{ name: 'Broken' }];
+
+  expect(view.querySelector('article')?.textContent).toBe('Existing');
+  expect(errors.at(-1)?.detail.code).toBe('missing-item-id');
+});
+
+it('keeps previous rendered items when duplicate item ids are provided', () => {
+  const view = new SearchCollectionViewElement();
+  const errors: CustomEvent[] = [];
+  view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+  view.renderer = (item) => {
+    const row = document.createElement('article');
+    row.textContent = String(item.name);
+    return row;
+  };
+  view.items = [{ id: 1, name: 'Existing' }];
+  document.body.append(view);
+
+  view.items = [
+    { id: 2, name: 'First' },
+    { id: 2, name: 'Second' },
+  ];
+
+  expect(view.querySelector('article')?.textContent).toBe('Existing');
+  expect(errors.at(-1)?.detail.code).toBe('duplicate-item-id');
+});
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: new id validation tests fail.
+
+- [ ] **Step 3: Implement id validation**
+
+Update `SearchCollectionViewElement` to:
+
+- Resolve ids with `item.id ?? getItemId?.(item, index)`.
+- Normalize ids with `String(id)`.
+- Reject `null`, `undefined`, and empty string ids.
+- Check duplicates before clearing or appending any item DOM.
+- Dispatch `component-error` with `missing-item-id` or `duplicate-item-id`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: all current core tests pass.
+
+## Task 4: Validate Custom Structure Lifecycle
+
+**Files:**
+- Modify: `tests/vitest/unit/components/searchCollectionView/core.spec.ts`
+- Modify: `src/components/searchCollectionView/SearchCollectionViewElement.ts`
+
+- [ ] **Step 1: Add RED tests for custom structure**
+
+Append tests that verify:
+
+```ts
+it('mounts a valid custom structure before first render', () => {
+  const view = new SearchCollectionViewElement();
+  view.structure = () => {
+    const toolbarRoot = document.createElement('header');
+    toolbarRoot.className = 'toolbar';
+    const root = document.createElement('section');
+    root.className = 'custom-root';
+    const itemsRoot = document.createElement('ol');
+    itemsRoot.className = 'custom-items';
+    root.append(itemsRoot);
+    return { root, itemsRoot, toolbarRoot };
+  };
+  view.renderer = () => document.createElement('li');
+  view.items = [{ id: 'a' }];
+  document.body.append(view);
+
+  expect(view.firstElementChild?.className).toBe('toolbar');
+  expect(view.children[1]?.className).toBe('custom-root');
+  expect(view.querySelector('.custom-items > li')?.getAttribute('data-item-id')).toBe('a');
+});
+
+it('rejects structure changes after structure is mounted', () => {
+  const view = new SearchCollectionViewElement();
+  const errors: CustomEvent[] = [];
+  view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+  view.renderer = () => document.createElement('article');
+  view.items = [{ id: 1 }];
+  document.body.append(view);
+
+  view.structure = () => {
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('div');
+    root.append(itemsRoot);
+    return { root, itemsRoot };
+  };
+
+  expect(errors.at(-1)?.detail.code).toBe('invalid-structure');
+  expect(view.querySelector('.scv__items')).not.toBeNull();
+});
+
+it('rejects invalid custom structures before item DOM changes', () => {
+  const view = new SearchCollectionViewElement();
+  const errors: CustomEvent[] = [];
+  view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+  view.structure = () => {
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('div');
+    return { root, itemsRoot };
+  };
+  view.renderer = () => document.createElement('article');
+  view.items = [{ id: 1 }];
+  document.body.append(view);
+
+  expect(errors.at(-1)?.detail.code).toBe('invalid-structure');
+  expect(view.querySelector('article')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: structure tests fail.
+
+- [ ] **Step 3: Implement structure validation and mounting**
+
+Update `SearchCollectionViewElement` to:
+
+- Lazily mount default or custom structure on first render.
+- Insert `toolbarRoot` before `root` when provided.
+- Create default `.scv__toolbar` when custom structure omits `toolbarRoot`.
+- Require fresh `HTMLElement` nodes.
+- Require `itemsRoot` to be contained by `modeRoot ?? root`.
+- Require `modeRoot`, when present, to be `root` or contained by `root`.
+- Reject `structure` changes after mount with `invalid-structure`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: all current core tests pass.
+
+## Task 5: Handle Renderer Fragments and Renderer Errors
+
+**Files:**
+- Modify: `tests/vitest/unit/components/searchCollectionView/core.spec.ts`
+- Modify: `src/components/searchCollectionView/SearchCollectionViewElement.ts`
+
+- [ ] **Step 1: Add RED tests for fragment wrapping and renderer errors**
+
+Append tests that verify:
+
+```ts
+it('wraps DocumentFragment renderer output in a default item wrapper', () => {
+  const view = new SearchCollectionViewElement();
+  view.renderer = () => {
+    const fragment = document.createDocumentFragment();
+    const label = document.createElement('span');
+    label.textContent = 'Fragment child';
+    fragment.append(label);
+    return fragment;
+  };
+  view.items = [{ id: 'fragment' }];
+  document.body.append(view);
+
+  const wrapper = view.querySelector<HTMLElement>('.scv__item');
+  expect(wrapper?.dataset.itemId).toBe('fragment');
+  expect(wrapper?.textContent).toBe('Fragment child');
+});
+
+it('continues rendering other items when a renderer throws', () => {
+  const view = new SearchCollectionViewElement();
+  const errors: CustomEvent[] = [];
+  view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+  view.renderer = (item) => {
+    if (item.id === 'bad') throw new Error('boom');
+    const row = document.createElement('article');
+    row.textContent = String(item.id);
+    return row;
+  };
+  view.items = [{ id: 'ok' }, { id: 'bad' }, { id: 'after' }];
+  document.body.append(view);
+
+  expect([...view.querySelectorAll('article')].map((row) => row.textContent)).toEqual(['ok', 'after']);
+  expect(view.querySelector<HTMLElement>('[data-render-error="true"]')?.dataset.itemId).toBe('bad');
+  expect(errors.at(-1)?.detail.code).toBe('renderer-error');
+});
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: fragment/error tests fail.
+
+- [ ] **Step 3: Implement fragment wrapping and renderer fallback**
+
+Update rendering to:
+
+- Adopt single `Element` renderer output as the item wrapper.
+- Wrap `DocumentFragment` output in `.scv__item`.
+- Apply `data-item-id` and `role="listitem"` to both adopted and default wrappers.
+- Catch renderer errors per item.
+- Create fallback `.scv__item[data-render-error="true"]` for failed items.
+- Dispatch `component-error` with `renderer-error`, `itemId`, and `cause`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: all current core tests pass.
+
+## Task 6: Final Verification for #586
+
+**Files:**
+- Modify only if verification finds a #586-scoped issue.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run all unit tests**
+
+Run:
+
+```bash
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run type check**
+
+Run:
+
+```bash
+npm run check:types
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Check diff for scope creep**
+
+Run:
+
+```bash
+git diff --stat
+```
+
+Expected: changes are limited to SearchCollectionView core, DOM test environment, plan doc, and entrypoint registration.
+
+## Self-Review
+
+- Spec coverage for #586:
+  - Custom element registration: Task 2.
+  - `items`, `setItems`, `getItemId`, `renderer`, `structure`: Tasks 2-4.
+  - Default structure and custom structure validation: Task 4.
+  - Scoped light DOM: Tasks 2 and 4.
+  - Item id validation: Task 3.
+  - Element adoption / DocumentFragment wrapping: Tasks 2 and 5.
+  - `aria-busy`, `render-complete`, `component-error`: Tasks 2, 3, and 5.
+- Intentional gaps:
+  - Selection, actions, mode plugins, search, CardList migration, and deck integration are explicitly left for later child issues.
+- Placeholder scan:
+  - No `TBD` or open-ended implementation placeholders remain.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,8 @@ const config = [
     ignores: [
       '**/.DS_Store',
       '**/node_modules/*',
+      '**/*-coverage/**',
+      '**/coverage/**',
       '**/dist',
       '**/package',
       '.env',

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vitest/ui": "^4.0.0",
         "eslint": "^10.0.0",
         "globals": "^17.4.0",
+        "happy-dom": "^20.9.0",
         "nyc": "^18.0.0",
         "playwright-test-coverage": "^1.2.12",
         "prettier": "^3.2.5",
@@ -1463,6 +1464,23 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
@@ -2242,6 +2260,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
@@ -2770,6 +2801,24 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4892,6 +4941,16 @@
         }
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4968,6 +5027,28 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@vitest/ui": "^4.0.0",
     "eslint": "^10.0.0",
     "globals": "^17.4.0",
+    "happy-dom": "^20.9.0",
     "nyc": "^18.0.0",
     "playwright-test-coverage": "^1.2.12",
     "prettier": "^3.2.5",

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -134,7 +134,6 @@ export class SearchCollectionViewElement<
     if (maybeStructure.modeRoot && !(maybeStructure.modeRoot instanceof HTMLElement)) return false;
     if (maybeStructure.toolbarRoot && !(maybeStructure.toolbarRoot instanceof HTMLElement)) return false;
     if (maybeStructure.itemsRoot === maybeStructure.root) return false;
-    if (maybeStructure.modeRoot && maybeStructure.modeRoot === maybeStructure.itemsRoot) return false;
     if (
       maybeStructure.toolbarRoot &&
       (maybeStructure.toolbarRoot === maybeStructure.root ||

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -120,6 +120,20 @@ export class SearchCollectionViewElement<
     if (!(structure.itemsRoot instanceof HTMLElement)) return false;
     if (structure.modeRoot && !(structure.modeRoot instanceof HTMLElement)) return false;
     if (structure.toolbarRoot && !(structure.toolbarRoot instanceof HTMLElement)) return false;
+    if (structure.itemsRoot === structure.root) return false;
+    if (structure.modeRoot && structure.modeRoot === structure.itemsRoot) return false;
+    if (
+      structure.toolbarRoot &&
+      (structure.toolbarRoot === structure.root ||
+        structure.toolbarRoot === structure.itemsRoot ||
+        structure.toolbarRoot === structure.modeRoot)
+    ) {
+      return false;
+    }
+    if (structure.root.isConnected || structure.itemsRoot.isConnected) return false;
+    if (structure.modeRoot?.isConnected || structure.toolbarRoot?.isConnected) return false;
+    if (structure.root.parentElement) return false;
+    if (structure.toolbarRoot?.parentElement) return false;
 
     const modeTarget = structure.modeRoot ?? structure.root;
     if (structure.modeRoot && structure.modeRoot !== structure.root && !structure.root.contains(structure.modeRoot)) {

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -71,7 +71,18 @@ export class SearchCollectionViewElement<
     if (this.mountedStructure) return this.mountedStructure;
 
     if (this._structure) {
-      const customStructure = this._structure();
+      let customStructure: unknown;
+      try {
+        customStructure = this._structure();
+      } catch (cause) {
+        this.dispatchComponentError({
+          code: 'invalid-structure',
+          message: 'Custom structure renderer failed.',
+          cause,
+        });
+        return null;
+      }
+
       if (!this.isValidStructure(customStructure)) {
         this.dispatchComponentError({
           code: 'invalid-structure',
@@ -115,32 +126,38 @@ export class SearchCollectionViewElement<
     return toolbarRoot;
   }
 
-  private isValidStructure(structure: SearchCollectionStructure) {
-    if (!(structure.root instanceof HTMLElement)) return false;
-    if (!(structure.itemsRoot instanceof HTMLElement)) return false;
-    if (structure.modeRoot && !(structure.modeRoot instanceof HTMLElement)) return false;
-    if (structure.toolbarRoot && !(structure.toolbarRoot instanceof HTMLElement)) return false;
-    if (structure.itemsRoot === structure.root) return false;
-    if (structure.modeRoot && structure.modeRoot === structure.itemsRoot) return false;
+  private isValidStructure(structure: unknown): structure is SearchCollectionStructure {
+    if (!structure || typeof structure !== 'object') return false;
+    const maybeStructure = structure as Partial<SearchCollectionStructure>;
+    if (!(maybeStructure.root instanceof HTMLElement)) return false;
+    if (!(maybeStructure.itemsRoot instanceof HTMLElement)) return false;
+    if (maybeStructure.modeRoot && !(maybeStructure.modeRoot instanceof HTMLElement)) return false;
+    if (maybeStructure.toolbarRoot && !(maybeStructure.toolbarRoot instanceof HTMLElement)) return false;
+    if (maybeStructure.itemsRoot === maybeStructure.root) return false;
+    if (maybeStructure.modeRoot && maybeStructure.modeRoot === maybeStructure.itemsRoot) return false;
     if (
-      structure.toolbarRoot &&
-      (structure.toolbarRoot === structure.root ||
-        structure.toolbarRoot === structure.itemsRoot ||
-        structure.toolbarRoot === structure.modeRoot)
+      maybeStructure.toolbarRoot &&
+      (maybeStructure.toolbarRoot === maybeStructure.root ||
+        maybeStructure.toolbarRoot === maybeStructure.itemsRoot ||
+        maybeStructure.toolbarRoot === maybeStructure.modeRoot)
     ) {
       return false;
     }
-    if (structure.root.isConnected || structure.itemsRoot.isConnected) return false;
-    if (structure.modeRoot?.isConnected || structure.toolbarRoot?.isConnected) return false;
-    if (structure.root.parentElement) return false;
-    if (structure.toolbarRoot?.parentElement) return false;
+    if (maybeStructure.root.isConnected || maybeStructure.itemsRoot.isConnected) return false;
+    if (maybeStructure.modeRoot?.isConnected || maybeStructure.toolbarRoot?.isConnected) return false;
+    if (maybeStructure.root.parentElement) return false;
+    if (maybeStructure.toolbarRoot?.parentElement) return false;
 
-    const modeTarget = structure.modeRoot ?? structure.root;
-    if (structure.modeRoot && structure.modeRoot !== structure.root && !structure.root.contains(structure.modeRoot)) {
+    const modeTarget = maybeStructure.modeRoot ?? maybeStructure.root;
+    if (
+      maybeStructure.modeRoot &&
+      maybeStructure.modeRoot !== maybeStructure.root &&
+      !maybeStructure.root.contains(maybeStructure.modeRoot)
+    ) {
       return false;
     }
 
-    return modeTarget.contains(structure.itemsRoot);
+    return modeTarget.contains(maybeStructure.itemsRoot);
   }
 
   private render(validatedItemIds?: string[]) {

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -1,0 +1,250 @@
+import type {
+  SearchCollectionItem,
+  SearchCollectionItemIdResolver,
+  SearchCollectionErrorDetail,
+  SearchCollectionRenderContext,
+  SearchCollectionRenderer,
+  SearchCollectionStructure,
+  SearchCollectionStructureRenderer,
+} from './types';
+
+export class SearchCollectionViewElement<
+  TItem extends SearchCollectionItem = SearchCollectionItem,
+> extends HTMLElement {
+  private _items: TItem[] = [];
+  private _renderer: SearchCollectionRenderer<TItem> | null = null;
+  private _getItemId: SearchCollectionItemIdResolver<TItem> | null = null;
+  private _structure: SearchCollectionStructureRenderer | null = null;
+  private mountedStructure: SearchCollectionStructure | null = null;
+  private hasReceivedItems = false;
+
+  get items() {
+    return this._items;
+  }
+
+  set items(items: TItem[]) {
+    this.setItems(items);
+  }
+
+  get renderer() {
+    return this._renderer;
+  }
+
+  set renderer(renderer: SearchCollectionRenderer<TItem> | null) {
+    this._renderer = renderer;
+    if (this.hasReceivedItems || this.mountedStructure) this.render();
+  }
+
+  get getItemId() {
+    return this._getItemId;
+  }
+
+  set getItemId(getItemId: SearchCollectionItemIdResolver<TItem> | null) {
+    this._getItemId = getItemId;
+    if (this.hasReceivedItems || this.mountedStructure) this.render();
+  }
+
+  get structure() {
+    return this._structure;
+  }
+
+  set structure(structure: SearchCollectionStructureRenderer | null) {
+    if (this.mountedStructure) {
+      this.dispatchComponentError({
+        code: 'invalid-structure',
+        message: 'Cannot change structure after it has been mounted.',
+      });
+      return;
+    }
+    this._structure = structure;
+  }
+
+  setItems(items: TItem[]) {
+    const itemIds = this.resolveItemIds(items);
+    if (!itemIds) return;
+    this.hasReceivedItems = true;
+    this._items = items;
+    this.render(itemIds);
+  }
+
+  private ensureStructure() {
+    if (this.mountedStructure) return this.mountedStructure;
+
+    if (this._structure) {
+      const customStructure = this._structure();
+      if (!this.isValidStructure(customStructure)) {
+        this.dispatchComponentError({
+          code: 'invalid-structure',
+          message: 'Custom structure must contain valid HTMLElement roots.',
+        });
+        return null;
+      }
+
+      const toolbarRoot = customStructure.toolbarRoot ?? this.createDefaultToolbarRoot();
+      this.append(toolbarRoot, customStructure.root);
+      this.mountedStructure = {
+        ...customStructure,
+        toolbarRoot,
+      };
+      return this.mountedStructure;
+    }
+
+    const mountedStructure = this.createDefaultStructure();
+    this.append(mountedStructure.toolbarRoot!, mountedStructure.root);
+    this.mountedStructure = mountedStructure;
+    return this.mountedStructure;
+  }
+
+  private createDefaultStructure() {
+    const toolbarRoot = this.createDefaultToolbarRoot();
+    const root = document.createElement('section');
+    root.className = 'scv';
+
+    const itemsRoot = document.createElement('div');
+    itemsRoot.className = 'scv__items';
+    itemsRoot.setAttribute('role', 'list');
+
+    root.append(itemsRoot);
+
+    return { root, itemsRoot, toolbarRoot };
+  }
+
+  private createDefaultToolbarRoot() {
+    const toolbarRoot = document.createElement('div');
+    toolbarRoot.className = 'scv__toolbar';
+    return toolbarRoot;
+  }
+
+  private isValidStructure(structure: SearchCollectionStructure) {
+    if (!(structure.root instanceof HTMLElement)) return false;
+    if (!(structure.itemsRoot instanceof HTMLElement)) return false;
+    if (structure.modeRoot && !(structure.modeRoot instanceof HTMLElement)) return false;
+    if (structure.toolbarRoot && !(structure.toolbarRoot instanceof HTMLElement)) return false;
+
+    const modeTarget = structure.modeRoot ?? structure.root;
+    if (structure.modeRoot && structure.modeRoot !== structure.root && !structure.root.contains(structure.modeRoot)) {
+      return false;
+    }
+
+    return modeTarget.contains(structure.itemsRoot);
+  }
+
+  private render(validatedItemIds?: string[]) {
+    const structure = this.ensureStructure();
+    if (!structure) return;
+    const itemIds = validatedItemIds ?? this.resolveItemIds(this._items);
+    if (!itemIds) return;
+
+    this.setAttribute('aria-busy', 'true');
+    structure.itemsRoot.replaceChildren();
+
+    try {
+      if (!this._renderer) {
+        this.dispatchRenderComplete([]);
+        return;
+      }
+
+      this._items.forEach((item, index) => {
+        const itemId = itemIds[index];
+
+        const context: SearchCollectionRenderContext<TItem> = {
+          itemId,
+          index,
+          selected: false,
+          mode: this.getAttribute('mode') ?? '',
+          emitAction: () => {},
+        };
+
+        try {
+          const rendered = this._renderer?.(item, context);
+          if (!rendered) return;
+          const wrapper = rendered instanceof Element ? rendered : this.wrapFragment(rendered);
+          this.applyItemWrapperState(wrapper, itemId);
+          structure.itemsRoot.append(wrapper);
+        } catch (cause) {
+          const fallback = document.createElement('div');
+          fallback.className = 'scv__item';
+          fallback.dataset.renderError = 'true';
+          this.applyItemWrapperState(fallback, itemId);
+          structure.itemsRoot.append(fallback);
+          this.dispatchComponentError({
+            code: 'renderer-error',
+            message: `Renderer failed for item "${itemId}".`,
+            cause,
+            itemId,
+          });
+        }
+      });
+
+      this.dispatchRenderComplete(itemIds);
+    } finally {
+      this.setAttribute('aria-busy', 'false');
+    }
+  }
+
+  private wrapFragment(fragment: DocumentFragment) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'scv__item';
+    wrapper.append(fragment);
+    return wrapper;
+  }
+
+  private applyItemWrapperState(wrapper: Element, itemId: string) {
+    wrapper.setAttribute('data-item-id', itemId);
+    wrapper.setAttribute('role', 'listitem');
+  }
+
+  private resolveItemIds(items: TItem[]) {
+    const itemIds: string[] = [];
+    const seen = new Set<string>();
+
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index];
+      const rawItemId = item.id ?? this._getItemId?.(item, index);
+      if (rawItemId === undefined || rawItemId === null || String(rawItemId) === '') {
+        this.dispatchComponentError({
+          code: 'missing-item-id',
+          message: `Missing item id at index ${index}.`,
+        });
+        return null;
+      }
+
+      const itemId = String(rawItemId);
+      if (seen.has(itemId)) {
+        this.dispatchComponentError({
+          code: 'duplicate-item-id',
+          message: `Duplicate item id "${itemId}".`,
+          itemId,
+        });
+        return null;
+      }
+
+      seen.add(itemId);
+      itemIds.push(itemId);
+    }
+
+    return itemIds;
+  }
+
+  private dispatchRenderComplete(itemIds: string[]) {
+    this.dispatchEvent(
+      new CustomEvent('render-complete', {
+        detail: { itemIds },
+      }),
+    );
+  }
+
+  private dispatchComponentError(detail: SearchCollectionErrorDetail) {
+    this.dispatchEvent(
+      new CustomEvent('component-error', {
+        detail,
+      }),
+    );
+  }
+}
+
+export function registerSearchCollectionViewElement() {
+  if (!customElements.get('search-collection-view')) {
+    customElements.define('search-collection-view', SearchCollectionViewElement);
+  }
+}

--- a/src/components/searchCollectionView/index.ts
+++ b/src/components/searchCollectionView/index.ts
@@ -1,0 +1,6 @@
+import { registerSearchCollectionViewElement } from './SearchCollectionViewElement';
+
+export * from './types';
+export { SearchCollectionViewElement, registerSearchCollectionViewElement } from './SearchCollectionViewElement';
+
+registerSearchCollectionViewElement();

--- a/src/components/searchCollectionView/types.ts
+++ b/src/components/searchCollectionView/types.ts
@@ -1,0 +1,42 @@
+export type SearchCollectionItem = Record<string, unknown> & {
+  id?: string | number;
+};
+
+export type SearchCollectionItemIdResolver<TItem extends SearchCollectionItem> = (
+  item: TItem,
+  index: number,
+) => string | number;
+
+export interface SearchCollectionRenderContext<TItem extends SearchCollectionItem> {
+  itemId: string;
+  index: number;
+  selected: boolean;
+  mode: string;
+  emitAction(action: string, detail?: Record<string, unknown>): void;
+}
+
+export type SearchCollectionRenderer<TItem extends SearchCollectionItem> = (
+  item: TItem,
+  context: SearchCollectionRenderContext<TItem>,
+) => Element | DocumentFragment;
+
+export interface SearchCollectionStructure {
+  root: HTMLElement;
+  modeRoot?: HTMLElement;
+  itemsRoot: HTMLElement;
+  toolbarRoot?: HTMLElement;
+}
+
+export type SearchCollectionStructureRenderer = () => SearchCollectionStructure;
+
+export interface SearchCollectionErrorDetail {
+  code: 'missing-item-id' | 'duplicate-item-id' | 'invalid-structure' | 'renderer-error';
+  message: string;
+  cause?: unknown;
+  itemId?: string;
+  mode?: string;
+}
+
+export interface SearchCollectionRenderCompleteDetail {
+  itemIds: string[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import '@/components/searchCollectionView';
 import '@/global';
 import '@/core';
 import '@/start';

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -156,6 +156,60 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(view.querySelector('article')).toBeNull();
   });
 
+  it('rejects custom structures that reuse connected nodes', () => {
+    const connectedRoot = document.createElement('section');
+    const connectedItemsRoot = document.createElement('ol');
+    connectedRoot.append(connectedItemsRoot);
+    document.body.append(connectedRoot);
+
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.structure = () => ({ root: connectedRoot, itemsRoot: connectedItemsRoot });
+    view.renderer = () => document.createElement('li');
+
+    view.items = [{ id: 'connected' }];
+
+    expect(errors[errors.length - 1]?.detail.code).toBe('invalid-structure');
+    expect(view.querySelector('li')).toBeNull();
+    expect(document.body.firstElementChild).toBe(connectedRoot);
+  });
+
+  it('rejects custom structure roots already parented outside the returned structure', () => {
+    const externalParent = document.createElement('div');
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('ol');
+    root.append(itemsRoot);
+    externalParent.append(root);
+
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.structure = () => ({ root, itemsRoot });
+    view.renderer = () => document.createElement('li');
+
+    view.items = [{ id: 'parented' }];
+
+    expect(errors[errors.length - 1]?.detail.code).toBe('invalid-structure');
+    expect(view.querySelector('li')).toBeNull();
+    expect(root.parentElement).toBe(externalParent);
+  });
+
+  it('rejects custom structures that reuse the same node for multiple roots', () => {
+    const root = document.createElement('section');
+
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.structure = () => ({ root, itemsRoot: root });
+    view.renderer = () => document.createElement('li');
+
+    view.items = [{ id: 'same-node' }];
+
+    expect(errors[errors.length - 1]?.detail.code).toBe('invalid-structure');
+    expect(view.querySelector('li')).toBeNull();
+  });
+
   it('wraps DocumentFragment renderer output in a default item wrapper', () => {
     const view = new SearchCollectionViewElement();
     view.renderer = () => {

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { SearchCollectionViewElement } from '@/components/searchCollectionView';
+
+describe('SearchCollectionViewElement core rendering', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders item elements from plain object data and an element renderer', () => {
+    const view = new SearchCollectionViewElement();
+    view.renderer = (item, context) => {
+      const row = document.createElement('article');
+      row.className = 'row';
+      row.textContent = `${context.itemId}:${String(item.name)}`;
+      return row;
+    };
+
+    view.items = [
+      { id: 1, name: 'Alpha' },
+      { id: 2, name: 'Beta' },
+    ];
+    document.body.append(view);
+
+    const rows = [...view.querySelectorAll<HTMLElement>('.row')];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.dataset.itemId)).toEqual(['1', '2']);
+    expect(rows.map((row) => row.textContent)).toEqual(['1:Alpha', '2:Beta']);
+    expect(view.querySelector('.scv__items')).not.toBeNull();
+  });
+
+  it('uses getItemId when item.id is absent', () => {
+    const view = new SearchCollectionViewElement<{ key: number; name: string }>();
+    view.getItemId = (item) => item.key;
+    view.renderer = (item) => {
+      const row = document.createElement('article');
+      row.textContent = item.name;
+      return row;
+    };
+
+    view.items = [{ key: 42, name: 'No id' }];
+    document.body.append(view);
+
+    expect(view.querySelector<HTMLElement>('article')?.dataset.itemId).toBe('42');
+  });
+
+  it('keeps previous rendered items when an item id is missing', () => {
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.renderer = (item) => {
+      const row = document.createElement('article');
+      row.textContent = String(item.name);
+      return row;
+    };
+    view.items = [{ id: 1, name: 'Existing' }];
+    document.body.append(view);
+
+    view.items = [{ name: 'Broken' }];
+
+    expect(view.querySelector('article')?.textContent).toBe('Existing');
+    expect(errors[errors.length - 1]?.detail.code).toBe('missing-item-id');
+  });
+
+  it('keeps previous rendered items when duplicate item ids are provided', () => {
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.renderer = (item) => {
+      const row = document.createElement('article');
+      row.textContent = String(item.name);
+      return row;
+    };
+    view.items = [{ id: 1, name: 'Existing' }];
+    document.body.append(view);
+
+    view.items = [
+      { id: 2, name: 'First' },
+      { id: 2, name: 'Second' },
+    ];
+
+    expect(view.querySelector('article')?.textContent).toBe('Existing');
+    expect(errors[errors.length - 1]?.detail.code).toBe('duplicate-item-id');
+  });
+
+  it('mounts a valid custom structure before first render', () => {
+    const view = new SearchCollectionViewElement();
+    view.structure = () => {
+      const toolbarRoot = document.createElement('header');
+      toolbarRoot.className = 'toolbar';
+      const root = document.createElement('section');
+      root.className = 'custom-root';
+      const itemsRoot = document.createElement('ol');
+      itemsRoot.className = 'custom-items';
+      root.append(itemsRoot);
+      return { root, itemsRoot, toolbarRoot };
+    };
+    view.renderer = () => document.createElement('li');
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    expect(view.firstElementChild?.className).toBe('toolbar');
+    expect(view.children[1]?.className).toBe('custom-root');
+    expect(view.querySelector('.custom-items > li')?.getAttribute('data-item-id')).toBe('a');
+  });
+
+  it('allows custom structure after renderer is set but before items create DOM', () => {
+    const view = new SearchCollectionViewElement();
+    view.renderer = () => document.createElement('li');
+    view.structure = () => {
+      const root = document.createElement('section');
+      root.className = 'late-root';
+      const itemsRoot = document.createElement('ol');
+      root.append(itemsRoot);
+      return { root, itemsRoot };
+    };
+
+    view.items = [{ id: 'late' }];
+    document.body.append(view);
+
+    expect(view.querySelector('.late-root li')?.getAttribute('data-item-id')).toBe('late');
+  });
+
+  it('rejects structure changes after structure is mounted', () => {
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.renderer = () => document.createElement('article');
+    view.items = [{ id: 1 }];
+    document.body.append(view);
+
+    view.structure = () => {
+      const root = document.createElement('section');
+      const itemsRoot = document.createElement('div');
+      root.append(itemsRoot);
+      return { root, itemsRoot };
+    };
+
+    expect(errors[errors.length - 1]?.detail.code).toBe('invalid-structure');
+    expect(view.querySelector('.scv__items')).not.toBeNull();
+  });
+
+  it('rejects invalid custom structures before item DOM changes', () => {
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.structure = () => {
+      const root = document.createElement('section');
+      const itemsRoot = document.createElement('div');
+      return { root, itemsRoot };
+    };
+    view.renderer = () => document.createElement('article');
+    view.items = [{ id: 1 }];
+    document.body.append(view);
+
+    expect(errors[errors.length - 1]?.detail.code).toBe('invalid-structure');
+    expect(view.querySelector('article')).toBeNull();
+  });
+
+  it('wraps DocumentFragment renderer output in a default item wrapper', () => {
+    const view = new SearchCollectionViewElement();
+    view.renderer = () => {
+      const fragment = document.createDocumentFragment();
+      const label = document.createElement('span');
+      label.textContent = 'Fragment child';
+      fragment.append(label);
+      return fragment;
+    };
+    view.items = [{ id: 'fragment' }];
+    document.body.append(view);
+
+    const wrapper = view.querySelector<HTMLElement>('.scv__item');
+    expect(wrapper?.dataset.itemId).toBe('fragment');
+    expect(wrapper?.textContent).toBe('Fragment child');
+  });
+
+  it('continues rendering other items when a renderer throws', () => {
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.renderer = (item) => {
+      if (item.id === 'bad') throw new Error('boom');
+      const row = document.createElement('article');
+      row.textContent = String(item.id);
+      return row;
+    };
+    view.items = [{ id: 'ok' }, { id: 'bad' }, { id: 'after' }];
+    document.body.append(view);
+
+    expect([...view.querySelectorAll('article')].map((row) => row.textContent)).toEqual(['ok', 'after']);
+    expect(view.querySelector<HTMLElement>('[data-render-error="true"]')?.dataset.itemId).toBe('bad');
+    expect(errors[errors.length - 1]?.detail.code).toBe('renderer-error');
+  });
+});

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -156,6 +156,39 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(view.querySelector('article')).toBeNull();
   });
 
+  it('rejects custom structure callbacks that return nullish values', () => {
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.structure = (() => null) as never;
+    view.renderer = () => document.createElement('article');
+
+    expect(() => {
+      view.items = [{ id: 1 }];
+    }).not.toThrow();
+
+    expect(errors[errors.length - 1]?.detail.code).toBe('invalid-structure');
+    expect(view.querySelector('article')).toBeNull();
+  });
+
+  it('reports invalid-structure when a custom structure callback throws', () => {
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.structure = (() => {
+      throw new Error('bad structure');
+    }) as never;
+    view.renderer = () => document.createElement('article');
+
+    expect(() => {
+      view.items = [{ id: 1 }];
+    }).not.toThrow();
+
+    expect(errors[errors.length - 1]?.detail.code).toBe('invalid-structure');
+    expect(errors[errors.length - 1]?.detail.cause).toBeInstanceOf(Error);
+    expect(view.querySelector('article')).toBeNull();
+  });
+
   it('rejects custom structures that reuse connected nodes', () => {
     const connectedRoot = document.createElement('section');
     const connectedItemsRoot = document.createElement('ol');

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -243,6 +243,24 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(view.querySelector('li')).toBeNull();
   });
 
+  it('allows modeRoot to be the same node as itemsRoot', () => {
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('ol');
+    root.append(itemsRoot);
+
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.structure = () => ({ root, modeRoot: itemsRoot, itemsRoot });
+    view.renderer = () => document.createElement('li');
+
+    view.items = [{ id: 'mode-items-root' }];
+    document.body.append(view);
+
+    expect(errors).toHaveLength(0);
+    expect(view.querySelector('ol > li')?.getAttribute('data-item-id')).toBe('mode-items-root');
+  });
+
   it('wraps DocumentFragment renderer output in a default item wrapper', () => {
     const view = new SearchCollectionViewElement();
     view.renderer = () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig(({ mode }) => {
         : [],
     ],
     test: {
+      environment: 'happy-dom',
       coverage: {
         enabled: true,
         provider: 'istanbul',


### PR DESCRIPTION
## Summary

- Implements the #586 SearchCollectionView core custom element with item rendering, id validation, structure mounting, and core render/error events.
- Adds DOM unit coverage for default/custom structure rendering, Element adoption, DocumentFragment wrapping, and renderer error fallback.
- Adds `happy-dom` for Vitest DOM tests and registers the component from the app entrypoint.

## Scope

This intentionally leaves selection/actions, view modes, search plugins, CardList adapter migration, and deck editor integration to the follow-up child issues tracked under #582.

Closes #586
Refs #582

## Test Plan

- `npm test`
- `npm run check:types`
- `npm run check:format`
- `npm run check:lint` exited 0 with one existing warning in `vitest-coverage/block-navigation.js`