### PR TITLE
SearchCollectionView に selection と item action を追加

### DIFF
--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -4,6 +4,7 @@ import type {
   SearchCollectionErrorDetail,
   SearchCollectionRenderContext,
   SearchCollectionRenderer,
+  SearchCollectionSelectionAttributeAdapter,
   SearchCollectionStructure,
   SearchCollectionStructureRenderer,
 } from './types';
@@ -15,6 +16,12 @@ export class SearchCollectionViewElement<
   private _renderer: SearchCollectionRenderer<TItem> | null = null;
   private _getItemId: SearchCollectionItemIdResolver<TItem> | null = null;
   private _structure: SearchCollectionStructureRenderer | null = null;
+  private _selectedItemIds = new Set<string>();
+  private _selectionAttribute: SearchCollectionSelectionAttributeAdapter = {
+    selected: 'true',
+    unselected: 'false',
+  };
+  private renderedItems = new Map<string, { item: TItem; wrapper: Element }>();
   private mountedStructure: SearchCollectionStructure | null = null;
   private hasReceivedItems = false;
 
@@ -59,6 +66,29 @@ export class SearchCollectionViewElement<
     this._structure = structure;
   }
 
+  get selectedItemIds(): ReadonlySet<string> {
+    return new Set(this._selectedItemIds);
+  }
+
+  get selectionAttribute() {
+    return { ...this._selectionAttribute };
+  }
+
+  set selectionAttribute(selectionAttribute: SearchCollectionSelectionAttributeAdapter) {
+    this._selectionAttribute = { ...selectionAttribute };
+    this.applySelectionStateToRenderedItems();
+  }
+
+  setSelectedItemIds(ids: Iterable<string | number>) {
+    const nextSelectedItemIds = new Set([...ids].map((id) => String(id)));
+    const previousSelectedItemIds = [...this._selectedItemIds];
+    if (this.areSetsEqual(this._selectedItemIds, nextSelectedItemIds)) return;
+
+    this._selectedItemIds = nextSelectedItemIds;
+    this.applySelectionStateToRenderedItems();
+    this.dispatchSelectionChange([...nextSelectedItemIds], previousSelectedItemIds);
+  }
+
   setItems(items: TItem[]) {
     const itemIds = this.resolveItemIds(items);
     if (!itemIds) return;
@@ -97,12 +127,14 @@ export class SearchCollectionViewElement<
         ...customStructure,
         toolbarRoot,
       };
+      this.attachItemActionDelegation(this.mountedStructure.itemsRoot);
       return this.mountedStructure;
     }
 
     const mountedStructure = this.createDefaultStructure();
     this.append(mountedStructure.toolbarRoot!, mountedStructure.root);
     this.mountedStructure = mountedStructure;
+    this.attachItemActionDelegation(this.mountedStructure.itemsRoot);
     return this.mountedStructure;
   }
 
@@ -167,6 +199,7 @@ export class SearchCollectionViewElement<
 
     this.setAttribute('aria-busy', 'true');
     structure.itemsRoot.replaceChildren();
+    this.renderedItems.clear();
 
     try {
       if (!this._renderer) {
@@ -180,9 +213,11 @@ export class SearchCollectionViewElement<
         const context: SearchCollectionRenderContext<TItem> = {
           itemId,
           index,
-          selected: false,
+          selected: this._selectedItemIds.has(itemId),
           mode: this.getAttribute('mode') ?? '',
-          emitAction: () => {},
+          emitAction: (action, detail) => {
+            this.dispatchItemAction(itemId, action, detail);
+          },
         };
 
         try {
@@ -190,12 +225,14 @@ export class SearchCollectionViewElement<
           if (!rendered) return;
           const wrapper = rendered instanceof Element ? rendered : this.wrapFragment(rendered);
           this.applyItemWrapperState(wrapper, itemId);
+          this.renderedItems.set(itemId, { item, wrapper });
           structure.itemsRoot.append(wrapper);
         } catch (cause) {
           const fallback = document.createElement('div');
           fallback.className = 'scv__item';
           fallback.dataset.renderError = 'true';
           this.applyItemWrapperState(fallback, itemId);
+          this.renderedItems.set(itemId, { item, wrapper: fallback });
           structure.itemsRoot.append(fallback);
           this.dispatchComponentError({
             code: 'renderer-error',
@@ -222,6 +259,22 @@ export class SearchCollectionViewElement<
   private applyItemWrapperState(wrapper: Element, itemId: string) {
     wrapper.setAttribute('data-item-id', itemId);
     wrapper.setAttribute('role', 'listitem');
+    this.applySelectionState(wrapper, this._selectedItemIds.has(itemId));
+  }
+
+  private applySelectionState(wrapper: Element, selected: boolean) {
+    const value = selected ? this._selectionAttribute.selected : this._selectionAttribute.unselected;
+    if (value === null) {
+      wrapper.removeAttribute('data-selected');
+    } else {
+      wrapper.setAttribute('data-selected', value);
+    }
+  }
+
+  private applySelectionStateToRenderedItems() {
+    for (const [itemId, renderedItem] of this.renderedItems) {
+      this.applySelectionState(renderedItem.wrapper, this._selectedItemIds.has(itemId));
+    }
   }
 
   private resolveItemIds(items: TItem[]) {
@@ -254,6 +307,71 @@ export class SearchCollectionViewElement<
     }
 
     return itemIds;
+  }
+
+  private areSetsEqual(left: Set<string>, right: Set<string>) {
+    if (left.size !== right.size) return false;
+    for (const value of left) {
+      if (!right.has(value)) return false;
+    }
+    return true;
+  }
+
+  private dispatchSelectionChange(selectedItemIds: string[], previousSelectedItemIds: string[]) {
+    this.dispatchEvent(
+      new CustomEvent('selection-change', {
+        detail: {
+          selectedItemIds,
+          previousSelectedItemIds,
+        },
+      }),
+    );
+  }
+
+  private attachItemActionDelegation(itemsRoot: HTMLElement) {
+    itemsRoot.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const actionElement = target.closest<HTMLElement>('[data-action]');
+      if (!actionElement || !itemsRoot.contains(actionElement)) return;
+
+      const itemId = this.findOwningRenderedItemId(actionElement, itemsRoot);
+      if (!itemId) return;
+
+      const action = actionElement.dataset.action;
+      if (!action) return;
+
+      this.dispatchItemAction(itemId, action);
+    });
+  }
+
+  private findOwningRenderedItemId(actionElement: Element, itemsRoot: HTMLElement) {
+    let current: Element | null = actionElement;
+    while (current && current !== itemsRoot) {
+      const itemId = current.getAttribute('data-item-id');
+      if (itemId && this.renderedItems.get(itemId)?.wrapper === current) {
+        return itemId;
+      }
+      current = current.parentElement;
+    }
+    return null;
+  }
+
+  private dispatchItemAction(itemId: string, action: string, detail?: Record<string, unknown>) {
+    const renderedItem = this.renderedItems.get(itemId);
+    if (!renderedItem) return;
+
+    this.dispatchEvent(
+      new CustomEvent('item-action', {
+        detail: {
+          itemId,
+          item: renderedItem.item,
+          action,
+          ...(detail === undefined ? {} : { detail }),
+        },
+      }),
+    );
   }
 
   private dispatchRenderComplete(itemIds: string[]) {

--- a/src/components/searchCollectionView/types.ts
+++ b/src/components/searchCollectionView/types.ts
@@ -40,3 +40,20 @@ export interface SearchCollectionErrorDetail {
 export interface SearchCollectionRenderCompleteDetail {
   itemIds: string[];
 }
+
+export interface SearchCollectionItemActionDetail<TItem extends SearchCollectionItem> {
+  itemId: string;
+  item: TItem;
+  action: string;
+  detail?: Record<string, unknown>;
+}
+
+export interface SearchCollectionSelectionAttributeAdapter {
+  selected: string;
+  unselected: string | null;
+}
+
+export interface SearchCollectionSelectionChangeDetail {
+  selectedItemIds: string[];
+  previousSelectedItemIds: string[];
+}

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -295,4 +295,209 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(view.querySelector<HTMLElement>('[data-render-error="true"]')?.dataset.itemId).toBe('bad');
     expect(errors[errors.length - 1]?.detail.code).toBe('renderer-error');
   });
+
+  it('updates selected item wrapper attributes without rerendering items', () => {
+    const view = new SearchCollectionViewElement();
+    let renderCount = 0;
+    const selectionChanges: CustomEvent[] = [];
+    view.addEventListener('selection-change', (event) => selectionChanges.push(event as CustomEvent));
+    view.renderer = (item, context) => {
+      renderCount += 1;
+      const row = document.createElement('article');
+      row.className = 'row';
+      row.textContent = `${context.itemId}:${context.selected ? 'selected' : 'unselected'}`;
+      return row;
+    };
+    view.items = [
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Beta' },
+    ];
+    document.body.append(view);
+
+    const rowsBefore = [...view.querySelectorAll<HTMLElement>('.row')];
+
+    view.setSelectedItemIds(['b']);
+
+    const rowsAfter = [...view.querySelectorAll<HTMLElement>('.row')];
+    expect(renderCount).toBe(2);
+    expect(rowsAfter).toEqual(rowsBefore);
+    expect(rowsAfter.map((row) => row.getAttribute('data-selected'))).toEqual(['false', 'true']);
+    expect([...view.selectedItemIds]).toEqual(['b']);
+    expect(selectionChanges).toHaveLength(1);
+    expect(selectionChanges[0]?.detail).toEqual({
+      selectedItemIds: ['b'],
+      previousSelectedItemIds: [],
+    });
+  });
+
+  it('passes selected snapshot to the renderer during item rendering', () => {
+    const view = new SearchCollectionViewElement();
+    const renderedSelectionStates: boolean[] = [];
+    view.setSelectedItemIds(['b']);
+    view.renderer = (_item, context) => {
+      renderedSelectionStates.push(context.selected);
+      const row = document.createElement('article');
+      row.className = 'row';
+      return row;
+    };
+
+    view.items = [{ id: 'a' }, { id: 'b' }];
+
+    expect(renderedSelectionStates).toEqual([false, true]);
+  });
+
+  it('dispatches item-action for data-action clicks inside the owning item wrapper', () => {
+    const view = new SearchCollectionViewElement<{ id: string; name: string }>();
+    const actions: CustomEvent[] = [];
+    view.addEventListener('item-action', (event) => actions.push(event as CustomEvent));
+    view.renderer = (item) => {
+      const row = document.createElement('article');
+      row.className = 'row';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.action = 'add';
+      button.textContent = item.name;
+      row.append(button);
+      return row;
+    };
+    view.items = [
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Beta' },
+    ];
+    document.body.append(view);
+
+    view.querySelector<HTMLButtonElement>('[data-item-id="b"] [data-action="add"]')?.click();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.detail).toEqual({
+      itemId: 'b',
+      item: { id: 'b', name: 'Beta' },
+      action: 'add',
+    });
+  });
+
+  it('dispatches item-action with the same detail shape from renderer context emitAction', () => {
+    const view = new SearchCollectionViewElement<{ id: string; name: string }>();
+    const actions: CustomEvent[] = [];
+    let emitFromItemB: () => void = () => {
+      throw new Error('emitAction was not captured');
+    };
+    view.addEventListener('item-action', (event) => actions.push(event as CustomEvent));
+    view.renderer = (item, context) => {
+      if (item.id === 'b') {
+        emitFromItemB = () => context.emitAction('delete', { source: 'keyboard' });
+      }
+      return document.createElement('article');
+    };
+    view.items = [
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Beta' },
+    ];
+    document.body.append(view);
+
+    emitFromItemB();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.detail).toEqual({
+      itemId: 'b',
+      item: { id: 'b', name: 'Beta' },
+      action: 'delete',
+      detail: { source: 'keyboard' },
+    });
+  });
+
+  it('ignores nested renderer-owned data-item-id when resolving delegated item actions', () => {
+    const view = new SearchCollectionViewElement<{ id: string; name: string }>();
+    const actions: CustomEvent[] = [];
+    view.addEventListener('item-action', (event) => actions.push(event as CustomEvent));
+    view.renderer = (item) => {
+      const row = document.createElement('article');
+      row.className = 'row';
+
+      if (item.id === 'b') {
+        const nested = document.createElement('span');
+        nested.dataset.itemId = 'a';
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.dataset.action = 'inspect';
+        button.textContent = item.name;
+        nested.append(button);
+        row.append(nested);
+      }
+
+      return row;
+    };
+    view.items = [
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Beta' },
+    ];
+    document.body.append(view);
+
+    view.querySelector<HTMLButtonElement>('[data-item-id="b"] [data-action="inspect"]')?.click();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.detail).toEqual({
+      itemId: 'b',
+      item: { id: 'b', name: 'Beta' },
+      action: 'inspect',
+    });
+  });
+
+  it('reapplies selected state to existing wrappers when selectionAttribute changes', () => {
+    const view = new SearchCollectionViewElement();
+    let renderCount = 0;
+    view.renderer = () => {
+      renderCount += 1;
+      const row = document.createElement('article');
+      row.className = 'row';
+      return row;
+    };
+    view.items = [{ id: 'a' }, { id: 'b' }];
+    document.body.append(view);
+    const rowsBefore = [...view.querySelectorAll<HTMLElement>('.row')];
+
+    view.setSelectedItemIds(['a']);
+    view.selectionAttribute = { selected: '1', unselected: null };
+
+    const rowsAfter = [...view.querySelectorAll<HTMLElement>('.row')];
+    expect(renderCount).toBe(2);
+    expect(rowsAfter).toEqual(rowsBefore);
+    expect(rowsAfter[0]?.getAttribute('data-selected')).toBe('1');
+    expect(rowsAfter[1]?.hasAttribute('data-selected')).toBe(false);
+  });
+
+  it('returns a selectionAttribute snapshot so external mutation cannot bypass the setter', () => {
+    const view = new SearchCollectionViewElement();
+    view.renderer = () => {
+      const row = document.createElement('article');
+      row.className = 'row';
+      return row;
+    };
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    const attributeSnapshot = view.selectionAttribute;
+    attributeSnapshot.selected = '1';
+    view.setSelectedItemIds(['a']);
+
+    expect(view.querySelector<HTMLElement>('.row')?.getAttribute('data-selected')).toBe('true');
+  });
+
+  it('copies assigned selectionAttribute so external mutation cannot bypass the setter', () => {
+    const view = new SearchCollectionViewElement();
+    view.renderer = () => {
+      const row = document.createElement('article');
+      row.className = 'row';
+      return row;
+    };
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    const adapter = { selected: '1', unselected: null };
+    view.selectionAttribute = adapter;
+    adapter.selected = '2';
+    view.setSelectedItemIds(['a']);
+
+    expect(view.querySelector<HTMLElement>('.row')?.getAttribute('data-selected')).toBe('1');
+  });
 });


### PR DESCRIPTION
## Summary

- Add selectedItemIds, setSelectedItemIds(), and selectionAttribute to SearchCollectionViewElement.
- Reflect selected state onto existing item wrappers without rerendering item DOM.
- Add delegated [data-action] handling and renderer context.emitAction() support for item-action events.
- Add public selection/action detail types and unit coverage for event detail shapes and nested data-item-id handling.

## Verification

- npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
- npm run check:types
- npm test -- --run

Closes #593
Parent: #582