### PR TITLE
Add SearchCollectionView view mode plugins

### DIFF
--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -6,6 +6,7 @@ import type {
   SearchCollectionRenderer,
   SearchCollectionStructure,
   SearchCollectionStructureRenderer,
+  ViewModePlugin,
 } from './types';
 
 export class SearchCollectionViewElement<
@@ -16,6 +17,7 @@ export class SearchCollectionViewElement<
   private _getItemId: SearchCollectionItemIdResolver<TItem> | null = null;
   private _structure: SearchCollectionStructureRenderer | null = null;
   private mountedStructure: SearchCollectionStructure | null = null;
+  private registeredViewModes: ViewModePlugin[] = [];
   private hasReceivedItems = false;
 
   get items() {
@@ -57,6 +59,23 @@ export class SearchCollectionViewElement<
       return;
     }
     this._structure = structure;
+  }
+
+  get viewModes(): readonly ViewModePlugin[] {
+    return Object.freeze([...this.registeredViewModes]);
+  }
+
+  registerViewMode(plugin: ViewModePlugin) {
+    if (this.registeredViewModes.some((viewMode) => viewMode.id === plugin.id)) {
+      this.dispatchComponentError({
+        code: 'duplicate-mode',
+        message: `Duplicate view mode "${plugin.id}".`,
+        mode: plugin.id,
+      });
+      return;
+    }
+
+    this.registeredViewModes.push(plugin);
   }
 
   setItems(items: TItem[]) {

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -262,14 +262,34 @@ export class SearchCollectionViewElement<
     const pluginChanged = previousPlugin?.id !== plugin.id;
     if (pluginChanged && previousPlugin) {
       this.removePluginClasses(previousPlugin, modeTarget);
-      previousPlugin.deactivate?.(modeTarget);
+      try {
+        previousPlugin.deactivate?.(modeTarget);
+      } catch (cause) {
+        this.dispatchComponentError({
+          code: 'view-mode-error',
+          message: `View mode "${previousPlugin.id}" deactivate hook failed.`,
+          cause,
+          mode: previousPlugin.id,
+        });
+      }
     }
 
     modeTarget.dataset.mode = plugin.id;
     this.addClassTokens(modeTarget, plugin.containerClass);
     [...structure.itemsRoot.children].forEach((child) => this.applyItemModeClass(child, plugin));
 
-    if (pluginChanged) plugin.activate?.(modeTarget);
+    if (pluginChanged) {
+      try {
+        plugin.activate?.(modeTarget);
+      } catch (cause) {
+        this.dispatchComponentError({
+          code: 'view-mode-error',
+          message: `View mode "${plugin.id}" activate hook failed.`,
+          cause,
+          mode: plugin.id,
+        });
+      }
+    }
   }
 
   private removePluginClasses(plugin: ViewModePlugin, modeTarget: HTMLElement) {

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -97,7 +97,7 @@ export class SearchCollectionViewElement<
     }
 
     this.registeredViewModes.push(plugin);
-    if (this.pendingMode === plugin.id) this.setMode(plugin.id);
+    if (this.pendingMode === plugin.id && this.getAttribute('mode') === plugin.id) this.setMode(plugin.id);
   }
 
   setItems(items: TItem[]) {
@@ -211,6 +211,7 @@ export class SearchCollectionViewElement<
         return;
       }
 
+      this.pendingMode = null;
       this.dispatchComponentError({
         code: 'unknown-mode',
         message: `Unknown view mode "${mode}".`,

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -12,12 +12,18 @@ import type {
 export class SearchCollectionViewElement<
   TItem extends SearchCollectionItem = SearchCollectionItem,
 > extends HTMLElement {
+  static get observedAttributes() {
+    return ['mode'];
+  }
+
   private _items: TItem[] = [];
   private _renderer: SearchCollectionRenderer<TItem> | null = null;
   private _getItemId: SearchCollectionItemIdResolver<TItem> | null = null;
   private _structure: SearchCollectionStructureRenderer | null = null;
   private mountedStructure: SearchCollectionStructure | null = null;
   private registeredViewModes: ViewModePlugin[] = [];
+  private activeMode: string | null = null;
+  private syncingModeAttribute = false;
   private hasReceivedItems = false;
 
   get items() {
@@ -63,6 +69,19 @@ export class SearchCollectionViewElement<
 
   get viewModes(): readonly ViewModePlugin[] {
     return Object.freeze([...this.registeredViewModes]);
+  }
+
+  get mode() {
+    return this.activeMode ?? '';
+  }
+
+  set mode(mode: string) {
+    this.setMode(mode);
+  }
+
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+    if (name !== 'mode' || oldValue === newValue || this.syncingModeAttribute) return;
+    this.setMode(newValue ?? '');
   }
 
   registerViewMode(plugin: ViewModePlugin) {
@@ -116,12 +135,14 @@ export class SearchCollectionViewElement<
         ...customStructure,
         toolbarRoot,
       };
+      if (this.activeMode) this.syncModeTarget(this.activeMode);
       return this.mountedStructure;
     }
 
     const mountedStructure = this.createDefaultStructure();
     this.append(mountedStructure.toolbarRoot!, mountedStructure.root);
     this.mountedStructure = mountedStructure;
+    if (this.activeMode) this.syncModeTarget(this.activeMode);
     return this.mountedStructure;
   }
 
@@ -178,6 +199,55 @@ export class SearchCollectionViewElement<
     return modeTarget.contains(maybeStructure.itemsRoot);
   }
 
+  private setMode(mode: string) {
+    const plugin = this.registeredViewModes.find((viewMode) => viewMode.id === mode);
+    if (!plugin) {
+      this.dispatchComponentError({
+        code: 'unknown-mode',
+        message: `Unknown view mode "${mode}".`,
+        mode,
+      });
+      this.syncHostModeAttribute(this.activeMode);
+      return;
+    }
+
+    if (this.activeMode === mode) {
+      this.syncHostModeAttribute(mode);
+      this.syncModeTarget(mode);
+      return;
+    }
+
+    const previousMode = this.activeMode;
+    this.activeMode = mode;
+    this.syncHostModeAttribute(mode);
+    this.syncModeTarget(mode);
+    this.dispatchModeChange(mode, previousMode);
+  }
+
+  private syncHostModeAttribute(mode: string | null) {
+    this.syncingModeAttribute = true;
+    try {
+      if (mode === null || mode === '') {
+        this.removeAttribute('mode');
+      } else if (this.getAttribute('mode') !== mode) {
+        this.setAttribute('mode', mode);
+      }
+    } finally {
+      this.syncingModeAttribute = false;
+    }
+  }
+
+  private syncModeTarget(mode: string) {
+    const modeTarget = this.getModeTarget();
+    if (modeTarget) modeTarget.dataset.mode = mode;
+  }
+
+  private getModeTarget() {
+    const structure = this.mountedStructure;
+    if (!structure) return null;
+    return structure.modeRoot ?? structure.root;
+  }
+
   private render(validatedItemIds?: string[]) {
     const structure = this.ensureStructure();
     if (!structure) return;
@@ -200,7 +270,7 @@ export class SearchCollectionViewElement<
           itemId,
           index,
           selected: false,
-          mode: this.getAttribute('mode') ?? '',
+          mode: this.mode,
           emitAction: () => {},
         };
 
@@ -273,6 +343,17 @@ export class SearchCollectionViewElement<
     }
 
     return itemIds;
+  }
+
+  private dispatchModeChange(mode: string, previousMode: string | null) {
+    this.dispatchEvent(
+      new CustomEvent('mode-change', {
+        detail: {
+          mode,
+          previousMode,
+        },
+      }),
+    );
   }
 
   private dispatchRenderComplete(itemIds: string[]) {

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -2,6 +2,7 @@ import type {
   SearchCollectionItem,
   SearchCollectionItemIdResolver,
   SearchCollectionErrorDetail,
+  SearchCollectionModeChangeDetail,
   SearchCollectionRenderContext,
   SearchCollectionRenderer,
   SearchCollectionStructure,
@@ -23,6 +24,7 @@ export class SearchCollectionViewElement<
   private mountedStructure: SearchCollectionStructure | null = null;
   private registeredViewModes: ViewModePlugin[] = [];
   private activeMode: string | null = null;
+  private pendingMode: string | null = null;
   private syncingModeAttribute = false;
   private hasReceivedItems = false;
 
@@ -95,6 +97,7 @@ export class SearchCollectionViewElement<
     }
 
     this.registeredViewModes.push(plugin);
+    if (this.pendingMode === plugin.id) this.setMode(plugin.id);
   }
 
   setItems(items: TItem[]) {
@@ -202,6 +205,12 @@ export class SearchCollectionViewElement<
   private setMode(mode: string) {
     const plugin = this.registeredViewModes.find((viewMode) => viewMode.id === mode);
     if (!plugin) {
+      if (this.registeredViewModes.length === 0) {
+        this.pendingMode = mode;
+        this.syncHostModeAttribute(mode);
+        return;
+      }
+
       this.dispatchComponentError({
         code: 'unknown-mode',
         message: `Unknown view mode "${mode}".`,
@@ -219,6 +228,7 @@ export class SearchCollectionViewElement<
 
     const previousMode = this.activeMode;
     this.activeMode = mode;
+    this.pendingMode = null;
     this.syncHostModeAttribute(mode);
     this.syncModeTarget(mode);
     this.dispatchModeChange(mode, previousMode);
@@ -346,12 +356,14 @@ export class SearchCollectionViewElement<
   }
 
   private dispatchModeChange(mode: string, previousMode: string | null) {
+    const detail: SearchCollectionModeChangeDetail = {
+      mode,
+      previousMode,
+    };
+
     this.dispatchEvent(
       new CustomEvent('mode-change', {
-        detail: {
-          mode,
-          previousMode,
-        },
+        detail,
       }),
     );
   }

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -23,6 +23,9 @@ export class SearchCollectionViewElement<
   private _structure: SearchCollectionStructureRenderer | null = null;
   private mountedStructure: SearchCollectionStructure | null = null;
   private registeredViewModes: ViewModePlugin[] = [];
+  private activeViewModePlugin: ViewModePlugin | null = null;
+  private installedStyleModes = new Set<string>();
+  private installedModeStyles = new Map<string, HTMLStyleElement>();
   private activeMode: string | null = null;
   private pendingMode: string | null = null;
   private syncingModeAttribute = false;
@@ -97,6 +100,7 @@ export class SearchCollectionViewElement<
     }
 
     this.registeredViewModes.push(plugin);
+    this.installModeStyles(plugin);
     if (this.pendingMode === plugin.id && this.getAttribute('mode') === plugin.id) this.setMode(plugin.id);
   }
 
@@ -138,14 +142,14 @@ export class SearchCollectionViewElement<
         ...customStructure,
         toolbarRoot,
       };
-      if (this.activeMode) this.syncModeTarget(this.activeMode);
+      if (this.activeViewModePlugin) this.applyViewModePlugin(this.activeViewModePlugin, null);
       return this.mountedStructure;
     }
 
     const mountedStructure = this.createDefaultStructure();
     this.append(mountedStructure.toolbarRoot!, mountedStructure.root);
     this.mountedStructure = mountedStructure;
-    if (this.activeMode) this.syncModeTarget(this.activeMode);
+    if (this.activeViewModePlugin) this.applyViewModePlugin(this.activeViewModePlugin, null);
     return this.mountedStructure;
   }
 
@@ -223,15 +227,17 @@ export class SearchCollectionViewElement<
 
     if (this.activeMode === mode) {
       this.syncHostModeAttribute(mode);
-      this.syncModeTarget(mode);
+      this.applyViewModePlugin(plugin, plugin);
       return;
     }
 
     const previousMode = this.activeMode;
+    const previousPlugin = this.activeViewModePlugin;
     this.activeMode = mode;
+    this.activeViewModePlugin = plugin;
     this.pendingMode = null;
     this.syncHostModeAttribute(mode);
-    this.syncModeTarget(mode);
+    this.applyViewModePlugin(plugin, previousPlugin);
     this.dispatchModeChange(mode, previousMode);
   }
 
@@ -248,9 +254,61 @@ export class SearchCollectionViewElement<
     }
   }
 
-  private syncModeTarget(mode: string) {
+  private applyViewModePlugin(plugin: ViewModePlugin, previousPlugin: ViewModePlugin | null) {
     const modeTarget = this.getModeTarget();
-    if (modeTarget) modeTarget.dataset.mode = mode;
+    const structure = this.mountedStructure;
+    if (!modeTarget || !structure) return;
+
+    const pluginChanged = previousPlugin?.id !== plugin.id;
+    if (pluginChanged && previousPlugin) {
+      this.removePluginClasses(previousPlugin, modeTarget);
+      previousPlugin.deactivate?.(modeTarget);
+    }
+
+    modeTarget.dataset.mode = plugin.id;
+    this.addClassTokens(modeTarget, plugin.containerClass);
+    [...structure.itemsRoot.children].forEach((child) => this.applyItemModeClass(child, plugin));
+
+    if (pluginChanged) plugin.activate?.(modeTarget);
+  }
+
+  private removePluginClasses(plugin: ViewModePlugin, modeTarget: HTMLElement) {
+    this.removeClassTokens(modeTarget, plugin.containerClass);
+    const structure = this.mountedStructure;
+    if (!structure) return;
+    [...structure.itemsRoot.children].forEach((child) => this.removeClassTokens(child, plugin.itemClass));
+  }
+
+  private applyItemModeClass(wrapper: Element, plugin = this.activeViewModePlugin) {
+    if (!plugin) return;
+    this.addClassTokens(wrapper, plugin.itemClass);
+  }
+
+  private addClassTokens(element: Element, className: string | undefined) {
+    const tokens = this.getClassTokens(className);
+    if (tokens.length > 0) element.classList.add(...tokens);
+  }
+
+  private removeClassTokens(element: Element, className: string | undefined) {
+    const tokens = this.getClassTokens(className);
+    if (tokens.length > 0) element.classList.remove(...tokens);
+  }
+
+  private getClassTokens(className: string | undefined) {
+    return className?.split(/\s+/).filter(Boolean) ?? [];
+  }
+
+  private installModeStyles(plugin: ViewModePlugin) {
+    if (!plugin.styles || this.installedStyleModes.has(plugin.id)) return;
+    const style = document.createElement('style');
+    style.dataset.viewMode = plugin.id;
+    style.textContent =
+      typeof plugin.styles === 'string'
+        ? plugin.styles
+        : [...plugin.styles.cssRules].map((rule) => rule.cssText).join('\n');
+    this.append(style);
+    this.installedStyleModes.add(plugin.id);
+    this.installedModeStyles.set(plugin.id, style);
   }
 
   private getModeTarget() {
@@ -322,6 +380,7 @@ export class SearchCollectionViewElement<
   private applyItemWrapperState(wrapper: Element, itemId: string) {
     wrapper.setAttribute('data-item-id', itemId);
     wrapper.setAttribute('role', 'listitem');
+    this.applyItemModeClass(wrapper);
   }
 
   private resolveItemIds(items: TItem[]) {

--- a/src/components/searchCollectionView/SearchCollectionViewElement.ts
+++ b/src/components/searchCollectionView/SearchCollectionViewElement.ts
@@ -106,9 +106,12 @@ export class SearchCollectionViewElement<
       return;
     }
 
-    this.registeredViewModes.push(plugin);
-    this.installModeStyles(plugin);
-    if (this.pendingMode === plugin.id && this.getAttribute('mode') === plugin.id) this.setMode(plugin.id);
+    const registeredPlugin = Object.freeze({ ...plugin });
+    this.registeredViewModes.push(registeredPlugin);
+    this.installModeStyles(registeredPlugin);
+    if (this.pendingMode === registeredPlugin.id && this.getAttribute('mode') === registeredPlugin.id) {
+      this.setMode(registeredPlugin.id);
+    }
   }
 
   get selectedItemIds(): ReadonlySet<string> {

--- a/src/components/searchCollectionView/types.ts
+++ b/src/components/searchCollectionView/types.ts
@@ -29,8 +29,29 @@ export interface SearchCollectionStructure {
 
 export type SearchCollectionStructureRenderer = () => SearchCollectionStructure;
 
+export interface ViewModePlugin {
+  id: string;
+  label: string;
+  containerClass?: string;
+  itemClass?: string;
+  styles?: string | CSSStyleSheet;
+  activate?(modeTarget: HTMLElement): void;
+  deactivate?(modeTarget: HTMLElement): void;
+}
+
+export interface SearchCollectionModeChangeDetail {
+  mode: string;
+  previousMode: string | null;
+}
+
 export interface SearchCollectionErrorDetail {
-  code: 'missing-item-id' | 'duplicate-item-id' | 'invalid-structure' | 'renderer-error';
+  code:
+    | 'missing-item-id'
+    | 'duplicate-item-id'
+    | 'unknown-mode'
+    | 'duplicate-mode'
+    | 'invalid-structure'
+    | 'renderer-error';
   message: string;
   cause?: unknown;
   itemId?: string;

--- a/src/components/searchCollectionView/types.ts
+++ b/src/components/searchCollectionView/types.ts
@@ -50,6 +50,7 @@ export interface SearchCollectionErrorDetail {
     | 'duplicate-item-id'
     | 'unknown-mode'
     | 'duplicate-mode'
+    | 'view-mode-error'
     | 'invalid-structure'
     | 'renderer-error';
   message: string;

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -329,4 +329,47 @@ describe('SearchCollectionViewElement core rendering', () => {
       mode: 'visual',
     });
   });
+
+  it('synchronizes the active mode to the host attribute and mode target dataset', () => {
+    const view = new SearchCollectionViewElement();
+    const modeRoot = document.createElement('section');
+    const root = document.createElement('div');
+    const itemsRoot = document.createElement('ol');
+    root.append(modeRoot);
+    modeRoot.append(itemsRoot);
+    view.structure = () => ({ root, modeRoot, itemsRoot });
+    view.renderer = () => document.createElement('li');
+    view.registerViewMode({ id: 'visual', label: 'Visual' });
+    view.registerViewMode({ id: 'list', label: 'List' });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    view.mode = 'visual';
+
+    expect(view.mode).toBe('visual');
+    expect(view.getAttribute('mode')).toBe('visual');
+    expect(modeRoot.dataset.mode).toBe('visual');
+
+    view.setAttribute('mode', 'list');
+
+    expect(view.mode).toBe('list');
+    expect(modeRoot.dataset.mode).toBe('list');
+  });
+
+  it('rejects an unknown mode and keeps the previous active mode', () => {
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.registerViewMode({ id: 'visual', label: 'Visual' });
+    view.mode = 'visual';
+
+    view.mode = 'missing';
+
+    expect(view.mode).toBe('visual');
+    expect(view.getAttribute('mode')).toBe('visual');
+    expect(errors[errors.length - 1]?.detail).toMatchObject({
+      code: 'unknown-mode',
+      mode: 'missing',
+    });
+  });
 });

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -314,6 +314,42 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(view.viewModes.map((mode) => mode.id)).toEqual(['visual', 'list', 'compact']);
   });
 
+  it('keeps registered view mode definitions immutable from caller mutations', () => {
+    const view = new SearchCollectionViewElement();
+    const visualMode = {
+      id: 'visual',
+      label: 'Visual',
+      containerClass: 'is-visual',
+      itemClass: 'item-visual',
+    };
+
+    view.registerViewMode(visualMode);
+    visualMode.id = 'list';
+    visualMode.containerClass = 'is-mutated';
+    visualMode.itemClass = 'item-mutated';
+    view.registerViewMode({ id: 'list', label: 'List' });
+
+    expect(view.viewModes.map((mode) => mode.id)).toEqual(['visual', 'list']);
+    expect(view.viewModes[0]).not.toBe(visualMode);
+    expect(Object.isFrozen(view.viewModes[0])).toBe(true);
+
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('ol');
+    root.append(itemsRoot);
+    view.structure = () => ({ root, itemsRoot });
+    view.renderer = () => document.createElement('li');
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    view.mode = 'visual';
+
+    expect(view.mode).toBe('visual');
+    expect(root.classList.contains('is-visual')).toBe(true);
+    expect(root.classList.contains('is-mutated')).toBe(false);
+    expect(view.querySelector('li')?.classList.contains('item-visual')).toBe(true);
+    expect(view.querySelector('li')?.classList.contains('item-mutated')).toBe(false);
+  });
+
   it('rejects duplicate view mode ids without replacing the existing plugin', () => {
     const view = new SearchCollectionViewElement();
     const errors: CustomEvent[] = [];

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -295,4 +295,38 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(view.querySelector<HTMLElement>('[data-render-error="true"]')?.dataset.itemId).toBe('bad');
     expect(errors[errors.length - 1]?.detail.code).toBe('renderer-error');
   });
+
+  it('registers view mode plugins and exposes a read-only snapshot', () => {
+    const view = new SearchCollectionViewElement();
+    const visualMode = { id: 'visual', label: 'Visual' };
+    const listMode = { id: 'list', label: 'List' };
+
+    view.registerViewMode(visualMode);
+    view.registerViewMode(listMode);
+
+    expect(view.viewModes).toEqual([visualMode, listMode]);
+    expect(Object.isFrozen(view.viewModes)).toBe(true);
+
+    const snapshot = view.viewModes;
+    view.registerViewMode({ id: 'compact', label: 'Compact' });
+
+    expect(snapshot).toEqual([visualMode, listMode]);
+    expect(view.viewModes.map((mode) => mode.id)).toEqual(['visual', 'list', 'compact']);
+  });
+
+  it('rejects duplicate view mode ids without replacing the existing plugin', () => {
+    const view = new SearchCollectionViewElement();
+    const errors: CustomEvent[] = [];
+    const visualMode = { id: 'visual', label: 'Visual' };
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+
+    view.registerViewMode(visualMode);
+    view.registerViewMode({ id: 'visual', label: 'Duplicate Visual' });
+
+    expect(view.viewModes).toEqual([visualMode]);
+    expect(errors[errors.length - 1]?.detail).toMatchObject({
+      code: 'duplicate-mode',
+      mode: 'visual',
+    });
+  });
 });

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -550,6 +550,91 @@ describe('SearchCollectionViewElement core rendering', () => {
     ]);
   });
 
+  it('reports activate hook errors without rejecting the active visual mode', () => {
+    const view = new SearchCollectionViewElement();
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('ol');
+    const errors: CustomEvent[] = [];
+    const cause = new Error('activate failed');
+    root.append(itemsRoot);
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.structure = () => ({ root, itemsRoot });
+    view.renderer = () => document.createElement('li');
+    view.registerViewMode({
+      id: 'visual',
+      label: 'Visual',
+      containerClass: 'is-visual',
+      itemClass: 'item-visual',
+      activate: () => {
+        throw cause;
+      },
+    });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    expect(() => {
+      view.mode = 'visual';
+    }).not.toThrow();
+
+    expect(errors[errors.length - 1]?.detail).toMatchObject({
+      code: 'view-mode-error',
+      mode: 'visual',
+      cause,
+    });
+    expect(view.mode).toBe('visual');
+    expect(view.getAttribute('mode')).toBe('visual');
+    expect(root.dataset.mode).toBe('visual');
+    expect(root.classList.contains('is-visual')).toBe(true);
+    expect(view.querySelector('li')?.classList.contains('item-visual')).toBe(true);
+  });
+
+  it('reports deactivate hook errors while switching to the new active mode', () => {
+    const view = new SearchCollectionViewElement();
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('ol');
+    const errors: CustomEvent[] = [];
+    const cause = new Error('deactivate failed');
+    root.append(itemsRoot);
+    view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
+    view.structure = () => ({ root, itemsRoot });
+    view.renderer = () => document.createElement('li');
+    view.registerViewMode({
+      id: 'visual',
+      label: 'Visual',
+      containerClass: 'is-visual',
+      itemClass: 'item-visual',
+      deactivate: () => {
+        throw cause;
+      },
+    });
+    view.registerViewMode({
+      id: 'list',
+      label: 'List',
+      containerClass: 'is-list',
+      itemClass: 'item-list',
+    });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+    view.mode = 'visual';
+
+    expect(() => {
+      view.mode = 'list';
+    }).not.toThrow();
+
+    expect(errors[errors.length - 1]?.detail).toMatchObject({
+      code: 'view-mode-error',
+      mode: 'visual',
+      cause,
+    });
+    expect(view.mode).toBe('list');
+    expect(view.getAttribute('mode')).toBe('list');
+    expect(root.dataset.mode).toBe('list');
+    expect(root.classList.contains('is-list')).toBe(true);
+    expect(root.classList.contains('is-visual')).toBe(false);
+    expect(view.querySelector('li')?.classList.contains('item-list')).toBe(true);
+    expect(view.querySelector('li')?.classList.contains('item-visual')).toBe(false);
+  });
+
   it('preserves item DOM and does not rerun renderer during mode switches', () => {
     const view = new SearchCollectionViewElement();
     const modeRoot = document.createElement('section');

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -462,25 +462,26 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(rowBefore).not.toBeNull();
 
     view.mode = 'visual';
+    const visualRow = view.querySelector<HTMLElement>('.row');
     expect(modeRoot.classList.contains('is-visual')).toBe(true);
     expect(modeRoot.classList.contains('is-list')).toBe(false);
-    expect(rowBefore?.classList.contains('item-visual')).toBe(true);
-    expect(rowBefore?.classList.contains('item-list')).toBe(false);
+    expect(visualRow?.classList.contains('item-visual')).toBe(true);
+    expect(visualRow?.classList.contains('item-list')).toBe(false);
 
     view.mode = 'list';
+    const listRow = view.querySelector<HTMLElement>('.row');
     expect(modeRoot.classList.contains('is-list')).toBe(true);
     expect(modeRoot.classList.contains('is-visual')).toBe(false);
-    expect(rowBefore?.classList.contains('item-list')).toBe(true);
-    expect(rowBefore?.classList.contains('item-visual')).toBe(false);
+    expect(listRow?.classList.contains('item-list')).toBe(true);
+    expect(listRow?.classList.contains('item-visual')).toBe(false);
 
     view.mode = 'visual';
 
-    const rowAfter = view.querySelector<HTMLElement>('.row');
-    expect(rowAfter).toBe(rowBefore);
+    const finalVisualRow = view.querySelector<HTMLElement>('.row');
     expect(modeRoot.classList.contains('is-visual')).toBe(true);
     expect(modeRoot.classList.contains('is-list')).toBe(false);
-    expect(rowAfter?.classList.contains('item-visual')).toBe(true);
-    expect(rowAfter?.classList.contains('item-list')).toBe(false);
+    expect(finalVisualRow?.classList.contains('item-visual')).toBe(true);
+    expect(finalVisualRow?.classList.contains('item-list')).toBe(false);
   });
 
   it('installs view mode styles once in registration order', () => {
@@ -503,9 +504,9 @@ describe('SearchCollectionViewElement core rendering', () => {
     view.items = [{ id: 'a' }];
     document.body.append(view);
 
-    view.mode = 'visual';
     view.mode = 'list';
     view.mode = 'visual';
+    view.mode = 'list';
 
     expect([...view.querySelectorAll('style')].map((style) => style.textContent)).toEqual([
       '.is-visual { display: grid; }',

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -356,6 +356,24 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(modeRoot.dataset.mode).toBe('list');
   });
 
+  it('synchronizes the active mode to the root dataset when modeRoot is omitted', () => {
+    const view = new SearchCollectionViewElement();
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('ol');
+    root.append(itemsRoot);
+    view.structure = () => ({ root, itemsRoot });
+    view.renderer = () => document.createElement('li');
+    view.registerViewMode({ id: 'visual', label: 'Visual' });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    view.mode = 'visual';
+
+    expect(view.mode).toBe('visual');
+    expect(view.getAttribute('mode')).toBe('visual');
+    expect(root.dataset.mode).toBe('visual');
+  });
+
   it('rejects an unknown mode and keeps the previous active mode', () => {
     const view = new SearchCollectionViewElement();
     const errors: CustomEvent[] = [];

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -565,20 +565,38 @@ describe('SearchCollectionViewElement core rendering', () => {
       row.className = 'row';
       return row;
     };
-    view.registerViewMode({ id: 'visual', label: 'Visual' });
-    view.registerViewMode({ id: 'list', label: 'List' });
+    view.registerViewMode({
+      id: 'visual',
+      label: 'Visual',
+      containerClass: 'is-visual',
+      itemClass: 'item-visual',
+    });
+    view.registerViewMode({
+      id: 'list',
+      label: 'List',
+      containerClass: 'is-list',
+      itemClass: 'item-list',
+    });
     view.items = [{ id: 'a' }];
     document.body.append(view);
     const rowBefore = view.querySelector<HTMLElement>('.row');
     expect(rowBefore).not.toBeNull();
 
     view.mode = 'visual';
+    const visualRow = view.querySelector<HTMLElement>('.row');
     view.mode = 'list';
+    const listRow = view.querySelector<HTMLElement>('.row');
     view.mode = 'visual';
 
     const rowAfter = view.querySelector<HTMLElement>('.row');
     expect(renderCount).toBe(1);
+    expect(visualRow).toBe(rowBefore);
+    expect(listRow).toBe(rowBefore);
     expect(rowAfter).toBe(rowBefore);
+    expect(modeRoot.classList.contains('is-visual')).toBe(true);
+    expect(modeRoot.classList.contains('is-list')).toBe(false);
+    expect(rowAfter?.classList.contains('item-visual')).toBe(true);
+    expect(rowAfter?.classList.contains('item-list')).toBe(false);
   });
 
   it('dispatches mode-change with mode and previousMode only when the mode changes', () => {

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -471,6 +471,11 @@ describe('SearchCollectionViewElement core rendering', () => {
 
     view.mode = 'visual';
     view.mode = 'list';
+    expect(modeRoot.classList.contains('is-list')).toBe(true);
+    expect(modeRoot.classList.contains('is-visual')).toBe(false);
+    expect(rowBefore?.classList.contains('item-list')).toBe(true);
+    expect(rowBefore?.classList.contains('item-visual')).toBe(false);
+
     view.mode = 'visual';
 
     const rowAfter = view.querySelector<HTMLElement>('.row');

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -374,6 +374,26 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(root.dataset.mode).toBe('visual');
   });
 
+  it('preserves a pre-existing mode attribute until the matching mode is registered', () => {
+    const view = new SearchCollectionViewElement();
+    const modeRoot = document.createElement('section');
+    const root = document.createElement('div');
+    const itemsRoot = document.createElement('ol');
+    root.append(modeRoot);
+    modeRoot.append(itemsRoot);
+    view.structure = () => ({ root, modeRoot, itemsRoot });
+    view.renderer = () => document.createElement('li');
+    view.setAttribute('mode', 'visual');
+
+    view.registerViewMode({ id: 'visual', label: 'Visual' });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    expect(view.mode).toBe('visual');
+    expect(view.getAttribute('mode')).toBe('visual');
+    expect(modeRoot.dataset.mode).toBe('visual');
+  });
+
   it('rejects an unknown mode and keeps the previous active mode', () => {
     const view = new SearchCollectionViewElement();
     const errors: CustomEvent[] = [];

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -394,6 +394,26 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(modeRoot.dataset.mode).toBe('visual');
   });
 
+  it('does not activate a stale pending mode after the host mode attribute is removed', () => {
+    const view = new SearchCollectionViewElement();
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('ol');
+    root.append(itemsRoot);
+    view.structure = () => ({ root, itemsRoot });
+    view.renderer = () => document.createElement('li');
+    view.setAttribute('mode', 'visual');
+    view.registerViewMode({ id: 'list', label: 'List' });
+
+    view.removeAttribute('mode');
+    view.registerViewMode({ id: 'visual', label: 'Visual' });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    expect(view.mode).toBe('');
+    expect(view.getAttribute('mode')).toBeNull();
+    expect(root.dataset.mode).toBeUndefined();
+  });
+
   it('rejects an unknown mode and keeps the previous active mode', () => {
     const view = new SearchCollectionViewElement();
     const errors: CustomEvent[] = [];

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -431,18 +431,15 @@ describe('SearchCollectionViewElement core rendering', () => {
     });
   });
 
-  it('switches mode classes, installs styles once, runs lifecycle hooks, and preserves item DOM', () => {
+  it('switches container and item classes across visual list visual modes', () => {
     const view = new SearchCollectionViewElement();
     const modeRoot = document.createElement('section');
     const root = document.createElement('div');
     const itemsRoot = document.createElement('ol');
     root.append(modeRoot);
     modeRoot.append(itemsRoot);
-    const calls: string[] = [];
-    let renderCount = 0;
     view.structure = () => ({ root, modeRoot, itemsRoot });
     view.renderer = () => {
-      renderCount += 1;
       const row = document.createElement('li');
       row.className = 'row';
       return row;
@@ -452,24 +449,24 @@ describe('SearchCollectionViewElement core rendering', () => {
       label: 'Visual',
       containerClass: 'is-visual',
       itemClass: 'item-visual',
-      styles: '.is-visual { display: grid; }',
-      activate: () => calls.push('activate:visual'),
-      deactivate: () => calls.push('deactivate:visual'),
     });
     view.registerViewMode({
       id: 'list',
       label: 'List',
       containerClass: 'is-list',
       itemClass: 'item-list',
-      styles: '.is-list { display: block; }',
-      activate: () => calls.push('activate:list'),
-      deactivate: () => calls.push('deactivate:list'),
     });
     view.items = [{ id: 'a' }];
     document.body.append(view);
     const rowBefore = view.querySelector<HTMLElement>('.row');
+    expect(rowBefore).not.toBeNull();
 
     view.mode = 'visual';
+    expect(modeRoot.classList.contains('is-visual')).toBe(true);
+    expect(modeRoot.classList.contains('is-list')).toBe(false);
+    expect(rowBefore?.classList.contains('item-visual')).toBe(true);
+    expect(rowBefore?.classList.contains('item-list')).toBe(false);
+
     view.mode = 'list';
     expect(modeRoot.classList.contains('is-list')).toBe(true);
     expect(modeRoot.classList.contains('is-visual')).toBe(false);
@@ -479,12 +476,70 @@ describe('SearchCollectionViewElement core rendering', () => {
     view.mode = 'visual';
 
     const rowAfter = view.querySelector<HTMLElement>('.row');
-    expect(renderCount).toBe(1);
     expect(rowAfter).toBe(rowBefore);
     expect(modeRoot.classList.contains('is-visual')).toBe(true);
     expect(modeRoot.classList.contains('is-list')).toBe(false);
     expect(rowAfter?.classList.contains('item-visual')).toBe(true);
     expect(rowAfter?.classList.contains('item-list')).toBe(false);
+  });
+
+  it('installs view mode styles once in registration order', () => {
+    const view = new SearchCollectionViewElement();
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('ol');
+    root.append(itemsRoot);
+    view.structure = () => ({ root, itemsRoot });
+    view.renderer = () => document.createElement('li');
+    view.registerViewMode({
+      id: 'visual',
+      label: 'Visual',
+      styles: '.is-visual { display: grid; }',
+    });
+    view.registerViewMode({
+      id: 'list',
+      label: 'List',
+      styles: '.is-list { display: block; }',
+    });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    view.mode = 'visual';
+    view.mode = 'list';
+    view.mode = 'visual';
+
+    expect([...view.querySelectorAll('style')].map((style) => style.textContent)).toEqual([
+      '.is-visual { display: grid; }',
+      '.is-list { display: block; }',
+    ]);
+  });
+
+  it('runs view mode lifecycle hooks in activation order', () => {
+    const view = new SearchCollectionViewElement();
+    const root = document.createElement('section');
+    const itemsRoot = document.createElement('ol');
+    root.append(itemsRoot);
+    const calls: string[] = [];
+    view.structure = () => ({ root, itemsRoot });
+    view.renderer = () => document.createElement('li');
+    view.registerViewMode({
+      id: 'visual',
+      label: 'Visual',
+      activate: () => calls.push('activate:visual'),
+      deactivate: () => calls.push('deactivate:visual'),
+    });
+    view.registerViewMode({
+      id: 'list',
+      label: 'List',
+      activate: () => calls.push('activate:list'),
+      deactivate: () => calls.push('deactivate:list'),
+    });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+
+    view.mode = 'visual';
+    view.mode = 'list';
+    view.mode = 'visual';
+
     expect(calls).toEqual([
       'activate:visual',
       'deactivate:visual',
@@ -492,10 +547,37 @@ describe('SearchCollectionViewElement core rendering', () => {
       'deactivate:list',
       'activate:visual',
     ]);
-    expect([...view.querySelectorAll('style')].map((style) => style.textContent)).toEqual([
-      '.is-visual { display: grid; }',
-      '.is-list { display: block; }',
-    ]);
+  });
+
+  it('preserves item DOM and does not rerun renderer during mode switches', () => {
+    const view = new SearchCollectionViewElement();
+    const modeRoot = document.createElement('section');
+    const root = document.createElement('div');
+    const itemsRoot = document.createElement('ol');
+    root.append(modeRoot);
+    modeRoot.append(itemsRoot);
+    let renderCount = 0;
+    view.structure = () => ({ root, modeRoot, itemsRoot });
+    view.renderer = () => {
+      renderCount += 1;
+      const row = document.createElement('li');
+      row.className = 'row';
+      return row;
+    };
+    view.registerViewMode({ id: 'visual', label: 'Visual' });
+    view.registerViewMode({ id: 'list', label: 'List' });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+    const rowBefore = view.querySelector<HTMLElement>('.row');
+    expect(rowBefore).not.toBeNull();
+
+    view.mode = 'visual';
+    view.mode = 'list';
+    view.mode = 'visual';
+
+    const rowAfter = view.querySelector<HTMLElement>('.row');
+    expect(renderCount).toBe(1);
+    expect(rowAfter).toBe(rowBefore);
   });
 
   it('dispatches mode-change with mode and previousMode only when the mode changes', () => {

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -430,4 +430,83 @@ describe('SearchCollectionViewElement core rendering', () => {
       mode: 'missing',
     });
   });
+
+  it('switches mode classes, installs styles once, runs lifecycle hooks, and preserves item DOM', () => {
+    const view = new SearchCollectionViewElement();
+    const modeRoot = document.createElement('section');
+    const root = document.createElement('div');
+    const itemsRoot = document.createElement('ol');
+    root.append(modeRoot);
+    modeRoot.append(itemsRoot);
+    const calls: string[] = [];
+    let renderCount = 0;
+    view.structure = () => ({ root, modeRoot, itemsRoot });
+    view.renderer = () => {
+      renderCount += 1;
+      const row = document.createElement('li');
+      row.className = 'row';
+      return row;
+    };
+    view.registerViewMode({
+      id: 'visual',
+      label: 'Visual',
+      containerClass: 'is-visual',
+      itemClass: 'item-visual',
+      styles: '.is-visual { display: grid; }',
+      activate: () => calls.push('activate:visual'),
+      deactivate: () => calls.push('deactivate:visual'),
+    });
+    view.registerViewMode({
+      id: 'list',
+      label: 'List',
+      containerClass: 'is-list',
+      itemClass: 'item-list',
+      styles: '.is-list { display: block; }',
+      activate: () => calls.push('activate:list'),
+      deactivate: () => calls.push('deactivate:list'),
+    });
+    view.items = [{ id: 'a' }];
+    document.body.append(view);
+    const rowBefore = view.querySelector<HTMLElement>('.row');
+
+    view.mode = 'visual';
+    view.mode = 'list';
+    view.mode = 'visual';
+
+    const rowAfter = view.querySelector<HTMLElement>('.row');
+    expect(renderCount).toBe(1);
+    expect(rowAfter).toBe(rowBefore);
+    expect(modeRoot.classList.contains('is-visual')).toBe(true);
+    expect(modeRoot.classList.contains('is-list')).toBe(false);
+    expect(rowAfter?.classList.contains('item-visual')).toBe(true);
+    expect(rowAfter?.classList.contains('item-list')).toBe(false);
+    expect(calls).toEqual([
+      'activate:visual',
+      'deactivate:visual',
+      'activate:list',
+      'deactivate:list',
+      'activate:visual',
+    ]);
+    expect([...view.querySelectorAll('style')].map((style) => style.textContent)).toEqual([
+      '.is-visual { display: grid; }',
+      '.is-list { display: block; }',
+    ]);
+  });
+
+  it('dispatches mode-change with mode and previousMode only when the mode changes', () => {
+    const view = new SearchCollectionViewElement();
+    const events: CustomEvent[] = [];
+    view.addEventListener('mode-change', (event) => events.push(event as CustomEvent));
+    view.registerViewMode({ id: 'visual', label: 'Visual' });
+    view.registerViewMode({ id: 'list', label: 'List' });
+
+    view.mode = 'visual';
+    view.mode = 'visual';
+    view.mode = 'list';
+
+    expect(events.map((event) => event.detail)).toEqual([
+      { mode: 'visual', previousMode: null },
+      { mode: 'list', previousMode: 'visual' },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- Add the SearchCollectionView view mode plugin API, including registration, read-only snapshots, duplicate validation, and mode state synchronization.
- Apply mode attributes, container/item classes, styles, lifecycle hooks, and mode-change events without recreating item DOM.
- Cover duplicate/unknown modes, declarative mode attributes, lifecycle errors, and DOM stability with Vitest tests.

## Test Plan
- npm test -- tests/vitest/unit/components/searchCollectionView/core.spec.ts
- npm run check:types
- npm test

Closes #587