### PR TITLE
[codex] Migrate CardList adapter structure to SearchCollectionView

### DIFF
--- a/src/components/cardList/index.ts
+++ b/src/components/cardList/index.ts
@@ -1,14 +1,7 @@
 import mustache from 'mustache';
 import { isValidString, $dom, mesureWidth } from '@/utils';
 import { toInt } from '@/utils/convert';
-import {
-  ICard,
-  RARITY,
-  inkCount,
-  encodeDeckCode,
-  availableInkCount,
-  availableSP,
-} from '@/models/card';
+import { ICard, RARITY, inkCount, encodeDeckCode, availableInkCount, availableSP } from '@/models/card';
 import { createCardGrid } from '@/components/cardGrid';
 import { ModalDialog } from '@/components/dialog';
 import {

--- a/src/components/cardList/index.ts
+++ b/src/components/cardList/index.ts
@@ -1,9 +1,21 @@
 import mustache from 'mustache';
 import { isValidString, $dom, mesureWidth } from '@/utils';
 import { toInt } from '@/utils/convert';
-import { ICard, RARITY, inkCount, encodeDeckCode, availableInkCount, availableSP } from '@/models/card';
+import {
+  ICard,
+  RARITY,
+  inkCount,
+  encodeDeckCode,
+  availableInkCount,
+  availableSP,
+} from '@/models/card';
 import { createCardGrid } from '@/components/cardGrid';
 import { ModalDialog } from '@/components/dialog';
+import {
+  SearchCollectionViewElement,
+  type SearchCollectionStructure,
+  type ViewModePlugin,
+} from '@/components/searchCollectionView';
 import tableHTML from './table.html.mustache?raw';
 import tableRowHTML from './row.html.mustache?raw';
 import deckInfoHTML from './deckInfoModalBody.html.mustache?raw';
@@ -15,6 +27,7 @@ interface IinternalSortRowInfo {
   gcount: number;
 }
 type sortJudgeFunc = (a: IinternalSortRowInfo, b: IinternalSortRowInfo) => number;
+
 interface IListOparationOpt {
   name?: string;
   maxg: number;
@@ -27,35 +40,60 @@ export interface ICardListOption {
   search: boolean;
   title: string;
 }
+
+type CardListItem = ICard & { id?: string | number };
+
+interface CardListStructure extends SearchCollectionStructure {
+  root: HTMLElement;
+  modeRoot: HTMLElement;
+  itemsRoot: HTMLUListElement;
+  toolbarRoot: HTMLElement;
+}
+
 export class CardList {
-  readonly wrapper: HTMLElement;
-  readonly body: HTMLTableSectionElement;
+  readonly wrapper: SearchCollectionViewElement<CardListItem>;
+  readonly body: HTMLUListElement;
   protected readonly srch: boolean;
+  protected readonly cards: CardListItem[] = [];
+
   constructor(option: ICardListOption) {
-    this.wrapper = $dom(mustache.render(tableHTML, { srch: option.search, title: option.title }));
-    this.body = this.wrapper.querySelector('.cardlist_table_body')!;
+    const template = $dom(mustache.render(tableHTML, { srch: option.search, title: option.title }));
+    const wrapper = new SearchCollectionViewElement<CardListItem>();
+    wrapper.className = template.className;
+    while (template.firstChild) wrapper.append(template.firstChild);
+    const tableCaption = wrapper.querySelector('.table-caption-title') as HTMLElement | null;
+    const table = this.createCardListStructure(tableCaption);
+    this.wrapper = wrapper;
+    this.body = table.itemsRoot;
     this.srch = option.search;
+
+    this.wrapper.structure = () => table;
+    this.wrapper.getItemId = (card) => card.id ?? card.n;
+    this.wrapper.renderer = (card) => createCardRow(card, this.srch);
+    this.wrapper.selectionAttribute = { selected: '1', unselected: null };
+    this.wrapper.hiddenItemClass = 'card--hidden';
+    this.wrapper.registerViewMode(this.createCardListViewMode('grid'));
+    this.wrapper.registerViewMode(this.createCardListViewMode('table'));
+    this.wrapper.mode = 'grid';
+
     {
-      // レイアウト変更ボタン
-      const layoutButtons = this.wrapper.querySelectorAll<HTMLElement>('[data-button_type]');
+      const layoutButtons = table.toolbarRoot.querySelectorAll<HTMLElement>('[data-button_type]');
       layoutButtons.forEach((el) => {
         el.addEventListener('click', (e) => {
-          const table = this.wrapper.querySelector('[data-layout]') as HTMLTableElement;
-          layoutButtons.forEach((el) => el.classList.remove('button-active'));
+          layoutButtons.forEach((button) => button.classList.remove('button-active'));
           const button = e.currentTarget as HTMLButtonElement;
           button.classList.add('button-active');
-          const layoutName = button.dataset['button_type']!;
-          table.dataset['layout'] = layoutName;
+          this.wrapper.mode = button.dataset['button_type']!;
         });
       });
 
-      // ソート変更
-      (this.wrapper.querySelector('.table-sort') as HTMLSelectElement).addEventListener('change', () => {
+      table.toolbarRoot.querySelector<HTMLSelectElement>('.table-sort')?.addEventListener('change', () => {
         this.filterSortRow();
       });
     }
+
     if (option.search) {
-      const form = this.wrapper.querySelector('.cardlist_serch') as HTMLFormElement;
+      const form = table.toolbarRoot.querySelector('.cardlist_serch') as HTMLFormElement;
       form.onsubmit = (e) => {
         e.preventDefault();
         this.filterSortRow();
@@ -63,47 +101,84 @@ export class CardList {
       form.querySelectorAll('.input-clear').forEach((el) =>
         el.addEventListener('click', () => {
           setTimeout(() => {
-            // クリア処理後に処理をするために、イベントハンドリング処理終了後に処理を実行する。
             this.filterSortRow();
           });
         }),
       );
       form.querySelector('.button_search_clear')!.addEventListener('click', () => {
         form.reset();
-        // clearableの状態変更
         form.querySelectorAll<HTMLElement>('[data-clearable]').forEach((el) => {
           el.dataset['clearable'] = '';
         });
         this.filterSortRow();
       });
     }
+
+    const activeModeButton = table.toolbarRoot.querySelector<HTMLButtonElement>('[data-button_type="grid"]');
+    activeModeButton?.classList.add('button-active');
+
+    tableCaption?.remove();
+    this.wrapper.items = this.cards;
   }
+
   findRowByNo(card_no: number) {
     return this.body.querySelector<HTMLElement>(`[data-card_no="${card_no}"]`);
   }
+
   addRow(...cards: ICard[]) {
-    const trs = cards.map((c) => createCardRow(c, this.srch));
-    this.filterSortRow(...trs);
+    this.cards.push(...cards);
+    this.renderCards();
   }
+
   findCardByNo(card_no: number) {
     const tr = this.findRowByNo(card_no);
     if (!tr) return null;
     return getCardRowInfo(tr);
   }
-  removeRowByNo(card_no: number) {
-    this.findRowByNo(card_no)?.remove();
-  }
-  /** リストをフィルター/ソートします */
-  filterSortRow(...added: HTMLElement[]) {
-    const trs = [...(this.body.children as HTMLCollectionOf<HTMLElement>), ...added];
-    const infoR = generateSortRowInfo(trs);
-    if (this.srch) {
-      const text = (this.wrapper.querySelector('.input_cardlist_serch') as HTMLInputElement).value;
-      const inputs = ['min-grid', 'max-grid', 'min-sp', 'max-sp'].map((idName, idx) => {
-        const e = this.wrapper.querySelector(`#${idName}`) as HTMLInputElement;
-        return toInt(e.value, idx & 1 ? Number.MAX_SAFE_INTEGER : 0);
-      });
 
+  removeRowByNo(card_no: number) {
+    const index = this.cards.findIndex((card) => card.n === card_no);
+    if (index >= 0) this.cards.splice(index, 1);
+    this.renderCards();
+  }
+
+  clearRows() {
+    this.cards.length = 0;
+    this.renderCards();
+  }
+
+  setSelectedCardNos(cardNos: Iterable<string | number>) {
+    this.wrapper.setSelectedItemIds(cardNos);
+  }
+
+  setCardSelected(cardNo: string | number, selected: boolean) {
+    const selectedNos = new Set(this.wrapper.selectedItemIds);
+    const key = String(cardNo);
+    if (selected) {
+      selectedNos.add(key);
+    } else {
+      selectedNos.delete(key);
+    }
+    this.wrapper.setSelectedItemIds(selectedNos);
+  }
+
+  checkRow(tr?: HTMLElement) {
+    this.wrapper.setSelectedItemIds(tr ? [tr.dataset['card_no'] ?? ''] : []);
+  }
+
+  filterSortRow() {
+    const sortVal = (this.wrapper.querySelector('.table-sort') as HTMLSelectElement).value;
+    const text = this.srch ? (this.wrapper.querySelector('.input_cardlist_serch') as HTMLInputElement).value : '';
+    const inputs = this.srch
+      ? ['min-grid', 'max-grid', 'min-sp', 'max-sp'].map((idName, idx) => {
+          const e = this.wrapper.querySelector(`#${idName}`) as HTMLInputElement;
+          return toInt(e.value, idx & 1 ? Number.MAX_SAFE_INTEGER : 0);
+        })
+      : [0, Number.MAX_SAFE_INTEGER, 0, Number.MAX_SAFE_INTEGER];
+
+    const cards = [...this.cards];
+    const infoR = generateSortRowInfo(cards.map((card) => this.findRowByNo(card.n)!).filter(Boolean));
+    if (this.srch) {
       filerRow(infoR, {
         name: text,
         ming: inputs[0],
@@ -112,32 +187,83 @@ export class CardList {
         maxsp: inputs[3],
       });
     }
-    const sortVal = (this.wrapper.querySelector('.table-sort') as HTMLSelectElement).value;
+
     infoR.sort(getSortRow(sortVal));
-    infoR.forEach((infos) => {
-      this.body.append(infos.row);
-    });
+    this.body.replaceChildren(...infoR.map((info) => info.row));
   }
-  checkRow(tr?: HTMLElement) {
-    const tableRows = [...this.body.childNodes] as HTMLElement[];
-    tableRows.forEach((row) => {
-      if (row == tr) {
-        tr.dataset['selected'] = '1';
-      } else {
-        row.dataset['selected'] = undefined;
-      }
-    });
+
+  protected renderCards() {
+    this.wrapper.items = [...this.cards];
+    this.filterSortRow();
+  }
+
+  protected createCardListStructure(tableCaption: HTMLElement | null): CardListStructure {
+    const root = document.createElement('div');
+    root.className = 'cardlist_table';
+    root.tabIndex = -1;
+    root.dataset.layout = 'grid';
+
+    const modeRoot = root;
+    modeRoot.dataset.mode = 'grid';
+
+    const head = document.createElement('div');
+    head.className = 'cardlist_table_head';
+    head.innerHTML = `
+      <div class="col-no text-center">
+        <span class="xl:hidden">No.</span><span class="hidden xl:inline">ナンバー</span>
+      </div>
+      <div class="col-gridcount flex items-center justify-center">
+        <div class="gridcount mr-3 after:h-3 after:w-3"></div>
+        <span>マス</span>
+      </div>
+      <div class="col-sp flex items-center justify-center">
+        <div class="sp-fill mr-px h-2 w-2"></div>
+        <span>SP</span>
+      </div>
+      <div class="col-rarity text-center">
+        <span class="hidden sm:inline md:hidden lg:inline">レア度</span>
+      </div>
+      <div class="col-name">名前</div>
+      <div class="col-action"></div>
+    `;
+
+    const itemsRoot = document.createElement('ul');
+    itemsRoot.className = 'cardlist_table_body';
+    itemsRoot.setAttribute('role', 'list');
+    modeRoot.append(head, itemsRoot);
+
+    const toolbarRoot = document.createElement('div');
+    if (tableCaption) {
+      toolbarRoot.className = tableCaption.className;
+      toolbarRoot.innerHTML = tableCaption.innerHTML;
+    } else {
+      toolbarRoot.className = 'cardlist_table_toolbar';
+    }
+
+    return { root, modeRoot, itemsRoot, toolbarRoot };
+  }
+
+  protected createCardListViewMode(id: 'grid' | 'table'): ViewModePlugin {
+    return {
+      id,
+      label: id,
+      activate(modeTarget) {
+        modeTarget.dataset.layout = id;
+        modeTarget.dataset.mode = id;
+      },
+    };
   }
 }
 
 function generateDeckInfoTitle(count: number) {
   return `デッキ (${count}/15)`;
 }
+
 export class DeckInfo extends CardList {
   constructor() {
     super({ search: false, title: generateDeckInfoTitle(0) });
     const btnDeckInfo = this.wrapper.querySelector('#button-deck-info') as HTMLElement;
-    btnDeckInfo.onclick = () => {
+    btnDeckInfo?.addEventListener('click', () => {
       const allInfo = [...(this.body.children as HTMLCollectionOf<HTMLElement>)].map((tr) => {
         const c = getCardRowInfo(tr);
         const gcount = inkCount(c.g, c.sg);
@@ -153,7 +279,6 @@ export class DeckInfo extends CardList {
         [0, new Map(availableInkCount.map((c) => [c, 0])), new Map(availableSP.map((c) => [c, 0]))],
       );
       const toStyleHeightLiteral = (n: number) => (isFinite(n) ? `style="height:${n}%"` : undefined);
-      // マス数の分布
       const _gcs = [...gcountr[1]];
       const gMaxCount = Math.max(..._gcs.map((v) => v[1]));
       const gcs = _gcs
@@ -162,7 +287,6 @@ export class DeckInfo extends CardList {
           v: toStyleHeightLiteral((g[1] * 100) / gMaxCount),
         }))
         .sort((a, b) => a.k - b.k);
-      // spの分布
       const _sp = [...gcountr[2]];
       const spMax = Math.max(..._sp.map((v) => v[1]));
       const sps = _sp
@@ -183,24 +307,46 @@ export class DeckInfo extends CardList {
       modal.element.querySelector(`[data-action="share"]`)?.addEventListener('click', function () {
         showShareMsg(encodeDeckCode(allInfo.map((info) => info.n)));
       });
-    };
+    });
   }
+
   removeRowByNo(card_no: number) {
     const row = super.findRowByNo(card_no);
     if (row) this.removeRow(row);
   }
-  addRow(...cards: ICard[]): void {
-    super.addRow(...cards);
-    this.showCount();
-  }
+
   removeRow(row: HTMLElement) {
-    row.remove();
+    const cardNo = toInt(row.dataset['card_no']);
+    const index = this.cards.findIndex((card) => card.n === cardNo);
+    if (index >= 0) {
+      this.cards.splice(index, 1);
+      this.renderCards();
+    } else {
+      row.remove();
+    }
     this.showCount();
   }
-  /** デッキの枚数をカウントします */
+
+  addRow(...cards: ICard[]): void {
+    const existingCardNos = new Set(this.cards.map((card) => card.n));
+    const uniqueCards = cards.filter((card) => {
+      if (existingCardNos.has(card.n)) return false;
+      existingCardNos.add(card.n);
+      return true;
+    });
+    if (uniqueCards.length > 0) super.addRow(...uniqueCards);
+    this.showCount();
+  }
+
+  clearRows() {
+    super.clearRows();
+    this.showCount();
+  }
+
   getCount() {
     return this.body.childElementCount;
   }
+
   showCount() {
     const count = this.getCount();
     let icon = '';
@@ -211,6 +357,7 @@ export class DeckInfo extends CardList {
     }
     this.wrapper.querySelector('.table-title-text')!.innerHTML = icon + generateDeckInfoTitle(count);
   }
+
   generateDeckCode() {
     const numbers = [...(this.body.children as HTMLCollectionOf<HTMLElement>)]
       .map((e) => toInt(e.dataset['card_no']))
@@ -227,6 +374,7 @@ function generateSortRowInfo(trs: HTMLElement[]): IinternalSortRowInfo[] {
     return { row, info, gcount };
   });
 }
+
 function filerRow(trs: IinternalSortRowInfo[], opt: IListOparationOpt) {
   const filterCondition = (info: IinternalSortRowInfo) => {
     if (isValidString(opt.name) && !info.info.ja.includes(opt.name)) return false;
@@ -256,6 +404,7 @@ const gcountAsc: sortJudgeFunc = (a, b) => {
   if (inf != 0) return inf;
   return noAsc(a, b);
 };
+
 const spAsc: sortJudgeFunc = (a, b) => {
   let inf = spJudge(a, b);
   if (inf != 0) return inf;
@@ -263,11 +412,13 @@ const spAsc: sortJudgeFunc = (a, b) => {
   if (inf != 0) return inf;
   return noAsc(a, b);
 };
+
 const rarityAsc: sortJudgeFunc = (a, b) => {
   const inf = rarityJudge(a, b);
   if (inf != 0) return inf;
   return gcountAsc(a, b);
 };
+
 function getSortRow(orderType: string): sortJudgeFunc {
   switch (orderType) {
     case '1':
@@ -289,7 +440,6 @@ function getSortRow(orderType: string): sortJudgeFunc {
   }
 }
 
-/** 行の内容からカードの情報に変換する */
 export function getCardRowInfo(tr: HTMLElement): ICard {
   const card_no = toInt(tr.dataset['card_no']);
   const card_sp = toInt(tr.querySelector('.card_sp')!.textContent?.trim());

--- a/src/components/cardList/row.html.mustache
+++ b/src/components/cardList/row.html.mustache
@@ -32,11 +32,11 @@
   </div>
   <div class="cardlist_table_item card_action">
     {{#notDeck}}
-    <button class="button-add button button-xs button-primary" title="デッキに追加">
+    <button class="button-add button button-xs button-primary" data-action="add" title="デッキに追加">
       <i class="fa fa-plus"></i>
     </button>
     {{/notDeck}}
-    <button class="button-delete button button-xs button-danger" title="デッキから削除">
+    <button class="button-delete button button-xs button-danger" data-action="delete" title="デッキから削除">
       <i class="fa fa-trash-can"></i>
     </button>
   </div>

--- a/src/components/cardList/table.html.mustache
+++ b/src/components/cardList/table.html.mustache
@@ -99,25 +99,4 @@
     </div>
     {{/srch}}
   </div>
-  <div class="cardlist_table" tabindex="-1" data-layout="grid">
-    <div class="cardlist_table_head">
-      <div class="col-no text-center">
-        <span class="xl:hidden">No.</span><span class="hidden xl:inline">ナンバー</span>
-      </div>
-      <div class="col-gridcount flex items-center justify-center">
-        <div class="gridcount mr-3 after:h-3 after:w-3"></div>
-        <span>マス</span>
-      </div>
-      <div class="col-sp flex items-center justify-center">
-        <div class="sp-fill mr-px h-2 w-2"></div>
-        <span>SP</span>
-      </div>
-      <div class="col-rarity text-center">
-        <span class="hidden sm:inline md:hidden lg:inline">レア度</span>
-      </div>
-      <div class="col-name">名前</div>
-      <div class="col-action"></div>
-    </div>
-    <ul class="cardlist_table_body"></ul>
-  </div>
 </div>

--- a/src/components/searchCollectionView/types.ts
+++ b/src/components/searchCollectionView/types.ts
@@ -1,4 +1,4 @@
-export type SearchCollectionItem = Record<string, unknown> & {
+export type SearchCollectionItem = {
   id?: string | number;
 };
 

--- a/src/core/deckEditor/index.ts
+++ b/src/core/deckEditor/index.ts
@@ -18,8 +18,6 @@ declare global {
   }
 }
 
-const SelTrAttr = 'selected';
-
 const cardListManager = new CardList({ search: true, title: 'カードリスト' });
 cardListManager.addRow(...getCardList().c);
 cardListManager.wrapper.classList.add('deck-tab-item--active', 'card-list-container');
@@ -36,22 +34,11 @@ deckEditManager.showCount = () => {
   defaultShowDeckCountFunc();
   tabBtns[1].innerHTML = deckEditManager.wrapper.querySelector('.table-title-text')!.innerHTML;
 };
-/** 全カード一覧のカード選択をすべて解除する */
-function deselectCards() {
-  ([...cardListManager.body.children] as HTMLElement[]).forEach((tr) => {
-    tr.dataset[SelTrAttr] = '';
-  });
-}
 /** デッキを読み込む */
 function loadDeck(code: string | null | undefined, id?: string) {
   const cardInfo = decodeDeckCode(code);
-  deckEditManager.body.innerHTML = '';
-  deselectCards();
-  cardInfo.forEach((info) => {
-    const tr = cardListManager.findRowByNo(info.n);
-    if (!tr) return;
-    tr.dataset[SelTrAttr] = '1';
-  });
+  deckEditManager.clearRows();
+  cardListManager.setSelectedCardNos(cardInfo.map((info) => info.n));
   deckEditManager.addRow(...cardInfo);
   deckEditManager.body.dataset['id'] = id;
 }
@@ -67,12 +54,12 @@ function loadDeck(code: string | null | undefined, id?: string) {
         const row = el.closest<HTMLElement>('.' + rowClassName)!;
         const info = getCardRowInfo(row);
         deckEditManager.addRow(info);
-        row.dataset[SelTrAttr] = '1';
+        cardListManager.setCardSelected(info.n, true);
       } else if (el.closest('.button-delete')) {
         const row = el.closest<HTMLElement>('.' + rowClassName)!;
         const no = toInt(row.dataset['card_no']);
         deckEditManager.removeRowByNo(no);
-        row.dataset[SelTrAttr] = '';
+        cardListManager.setCardSelected(no, false);
       }
     });
   });
@@ -84,7 +71,7 @@ function loadDeck(code: string | null | undefined, id?: string) {
         const row = el.closest<HTMLElement>('.' + rowClassName)!;
         const no = toInt(row.dataset['card_no']);
         const r = cardListManager.findRowByNo(no);
-        if (r) r.dataset[SelTrAttr] = '';
+        if (r) cardListManager.setCardSelected(no, false);
         deckEditManager.removeRow(row);
       }
     });

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -1,18 +1,9 @@
 import { decodeDeckCode } from '@/models/card';
-
-const SelTrAttr = 'selected';
 /** デッキ編集画面にデッキを読み込む */
 export function loadDeck(code: string | null | undefined, id?: string) {
   const cardInfo = decodeDeckCode(code);
-  window.DeckEditManager.body.innerHTML = '';
-  ([...window.CardListManager.body.children] as HTMLElement[]).forEach((tr) => {
-    tr.dataset[SelTrAttr] = '';
-  });
-  cardInfo.forEach((info) => {
-    const tr = window.CardListManager.findRowByNo(info.n);
-    if (!tr) return;
-    tr.dataset[SelTrAttr] = '1';
-  });
+  window.DeckEditManager.clearRows();
+  window.CardListManager.setSelectedCardNos(cardInfo.map((info) => info.n));
   window.DeckEditManager.addRow(...cardInfo);
   window.DeckEditManager.body.dataset['id'] = id;
 }

--- a/tests/e2e/test/mobile/cardList.spec.ts
+++ b/tests/e2e/test/mobile/cardList.spec.ts
@@ -38,3 +38,29 @@ test('select card and clear', async ({ page, cardUtil }) => {
   await cardUtil.getCardByIdFromList(20).getByRole('button', { name: 'デッキから削除' }).click();
   await expect(page.getByText('カードリスト デッキ (0/15)')).toBeInViewport();
 });
+
+test('preserves card row identity and selected display while switching layouts on mobile tabs', async ({
+  page,
+  cardUtil,
+}) => {
+  await page.goto('/');
+  await cardUtil.showCardList();
+
+  const table = page.locator('.card-list-container .cardlist_table');
+  const card = cardUtil.getCardByIdFromList(1);
+  await expect(table).toHaveAttribute('data-layout', 'grid');
+
+  await card.getByRole('button', { name: 'デッキに追加' }).click();
+  await expect(card).toHaveAttribute('data-selected', '1');
+
+  const cardHandle = await card.elementHandle();
+  await page.locator('.card-list-container [data-button_type="table"]').click();
+  await expect(table).toHaveAttribute('data-layout', 'table');
+  expect(await card.evaluate((node, previous) => node === previous, cardHandle)).toBe(true);
+  await expect(card).toHaveAttribute('data-selected', '1');
+
+  await page.locator('.card-list-container [data-button_type="grid"]').click();
+  await expect(table).toHaveAttribute('data-layout', 'grid');
+  expect(await card.evaluate((node, previous) => node === previous, cardHandle)).toBe(true);
+  await expect(card).toHaveAttribute('data-selected', '1');
+});

--- a/tests/e2e/test/pc/cardList.spec.ts
+++ b/tests/e2e/test/pc/cardList.spec.ts
@@ -35,3 +35,28 @@ test('select card and clear', async ({ page, cardUtil }) => {
   await expect(page.locator('li').filter({ hasText: 'N-ZAP85' }).getByRole('button')).toHaveCount(2);
   await page.locator('li').filter({ hasText: 'N-ZAP85' }).getByRole('button').nth(1).click();
 });
+
+test('preserves card row identity and selected display while switching layouts', async ({ page, cardUtil }) => {
+  await page.goto('/');
+
+  const table = page.locator('.card-list-container .cardlist_table');
+  const card = cardUtil.getCardByIdFromList(1);
+  await expect(table).toHaveAttribute('data-layout', 'grid');
+  await expect(card).not.toHaveAttribute('data-selected', '1');
+
+  await card.getByRole('button', { name: 'デッキに追加' }).click();
+  await expect(card).toHaveAttribute('data-selected', '1');
+  await expect(card.getByRole('button', { name: 'デッキに追加' })).toBeHidden();
+  await expect(card.getByRole('button', { name: 'デッキから削除' })).toBeVisible();
+
+  const cardHandle = await card.elementHandle();
+  await page.locator('.card-list-container [data-button_type="table"]').click();
+  await expect(table).toHaveAttribute('data-layout', 'table');
+  expect(await card.evaluate((node, previous) => node === previous, cardHandle)).toBe(true);
+  await expect(card).toHaveAttribute('data-selected', '1');
+
+  await page.locator('.card-list-container [data-button_type="grid"]').click();
+  await expect(table).toHaveAttribute('data-layout', 'grid');
+  expect(await card.evaluate((node, previous) => node === previous, cardHandle)).toBe(true);
+  await expect(card).toHaveAttribute('data-selected', '1');
+});

--- a/tests/vitest/unit/components/cardList/adapter.spec.ts
+++ b/tests/vitest/unit/components/cardList/adapter.spec.ts
@@ -94,10 +94,9 @@ describe('CardList SearchCollectionView adapter', () => {
 
     deckInfo.addRow(cards[0]!);
 
-    expect([...deckInfo.body.querySelectorAll<HTMLElement>('li.cardlist_table_row')].map((row) => row.dataset.card_no)).toEqual([
-      '1',
-      '2',
-    ]);
+    expect(
+      [...deckInfo.body.querySelectorAll<HTMLElement>('li.cardlist_table_row')].map((row) => row.dataset.card_no),
+    ).toEqual(['1', '2']);
   });
 
   it('exposes DeckInfo toolbar actions before rows are added', () => {

--- a/tests/vitest/unit/components/cardList/adapter.spec.ts
+++ b/tests/vitest/unit/components/cardList/adapter.spec.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { CardList, DeckInfo, getCardRowInfo } from '@/components/cardList';
+import type { ICard } from '@/models/card';
+
+const cards: ICard[] = [
+  { n: 1, r: 0, sp: 2, ja: 'Alpha', g: '10', sg: '' },
+  { n: 2, r: 1, sp: 3, ja: 'Beta', g: '11', sg: '' },
+];
+
+describe('CardList SearchCollectionView adapter', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('mounts the preserved toolbar and table structure in light DOM', () => {
+    const cardList = new CardList({ search: true, title: 'カードリスト' });
+    cardList.addRow(...cards);
+    document.body.append(cardList.wrapper);
+
+    expect(cardList.wrapper.tagName.toLowerCase()).toBe('search-collection-view');
+    expect(cardList.wrapper.classList.contains('deck-tab-item')).toBe(true);
+    expect(cardList.wrapper.classList.contains('table__wrapper')).toBe(true);
+    expect(cardList.wrapper.firstElementChild?.classList.contains('table-caption-title')).toBe(true);
+
+    const table = cardList.wrapper.querySelector<HTMLElement>('.cardlist_table');
+    expect(table).not.toBeNull();
+    expect(table?.dataset.layout).toBe('grid');
+    expect(table?.dataset.mode).toBe('grid');
+    expect(table?.previousElementSibling?.classList.contains('table-caption-title')).toBe(true);
+    expect(table?.querySelector('.cardlist_table_head + ul.cardlist_table_body')).not.toBeNull();
+    expect(cardList.body.tagName.toLowerCase()).toBe('ul');
+  });
+
+  it('renders CardList rows as li.cardlist_table_row roots with compatibility data', () => {
+    const cardList = new CardList({ search: true, title: 'カードリスト' });
+    cardList.addRow(...cards);
+    document.body.append(cardList.wrapper);
+
+    const rows = [...cardList.body.querySelectorAll<HTMLElement>('li.cardlist_table_row')];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.dataset.itemId)).toEqual(['1', '2']);
+    expect(rows.map((row) => row.dataset.card_no)).toEqual(['1', '2']);
+    expect(rows.map((row) => row.dataset.card_rarity)).toEqual(['0', '1']);
+    expect(rows.map((row) => row.dataset.card_spx)).toEqual(['', '']);
+    expect(rows.map((row) => row.dataset.card_px)).toEqual(['10', '11']);
+    expect(rows[0]?.getAttribute('role')).toBe('listitem');
+    expect(rows[0]?.querySelector('.button-add')?.getAttribute('data-action')).toBe('add');
+    expect(rows[0]?.querySelector('.button-delete')?.getAttribute('data-action')).toBe('delete');
+    expect(getCardRowInfo(rows[1]!)).toEqual(cards[1]);
+  });
+
+  it('switches grid and table modes through SearchCollectionView while preserving row nodes', () => {
+    const cardList = new CardList({ search: true, title: 'カードリスト' });
+    cardList.addRow(...cards);
+    document.body.append(cardList.wrapper);
+
+    const table = cardList.wrapper.querySelector<HTMLElement>('.cardlist_table')!;
+    const rowsBefore = [...cardList.body.querySelectorAll<HTMLElement>('li.cardlist_table_row')];
+
+    cardList.wrapper.querySelector<HTMLButtonElement>('[data-button_type="table"]')!.click();
+
+    expect(table.dataset.layout).toBe('table');
+    expect(table.dataset.mode).toBe('table');
+    expect([...cardList.body.querySelectorAll<HTMLElement>('li.cardlist_table_row')]).toEqual(rowsBefore);
+
+    cardList.wrapper.querySelector<HTMLButtonElement>('[data-button_type="grid"]')!.click();
+
+    expect(table.dataset.layout).toBe('grid');
+    expect(table.dataset.mode).toBe('grid');
+    expect([...cardList.body.querySelectorAll<HTMLElement>('li.cardlist_table_row')]).toEqual(rowsBefore);
+  });
+
+  it('keeps selected row display compatible with data-selected equals 1', () => {
+    const cardList = new CardList({ search: true, title: 'カードリスト' });
+    cardList.addRow(...cards);
+    document.body.append(cardList.wrapper);
+
+    cardList.setSelectedCardNos([2]);
+
+    expect(cardList.findRowByNo(1)?.hasAttribute('data-selected')).toBe(false);
+    expect(cardList.findRowByNo(2)?.getAttribute('data-selected')).toBe('1');
+  });
+
+  it('keeps DeckInfo item state synchronized when rows are removed by element', () => {
+    const deckInfo = new DeckInfo();
+    deckInfo.addRow(...cards);
+    document.body.append(deckInfo.wrapper);
+
+    deckInfo.removeRow(deckInfo.findRowByNo(1)!);
+
+    expect(deckInfo.findRowByNo(1)).toBeNull();
+    expect(deckInfo.findRowByNo(2)).not.toBeNull();
+    expect(deckInfo.getCount()).toBe(1);
+
+    deckInfo.addRow(cards[0]!);
+
+    expect([...deckInfo.body.querySelectorAll<HTMLElement>('li.cardlist_table_row')].map((row) => row.dataset.card_no)).toEqual([
+      '1',
+      '2',
+    ]);
+  });
+
+  it('exposes DeckInfo toolbar actions before rows are added', () => {
+    const deckInfo = new DeckInfo();
+
+    expect(deckInfo.wrapper.querySelector('#button-deck-info')).not.toBeNull();
+    expect(deckInfo.wrapper.querySelector('.action-wrapper')).not.toBeNull();
+    expect(deckInfo.wrapper.querySelector('.table-title-text')?.textContent).toBe('デッキ (0/15)');
+  });
+
+  it('clears rows through the adapter item state', () => {
+    const deckInfo = new DeckInfo();
+    deckInfo.addRow(...cards);
+    document.body.append(deckInfo.wrapper);
+
+    deckInfo.clearRows();
+
+    expect(deckInfo.body.children).toHaveLength(0);
+    expect(deckInfo.getCount()).toBe(0);
+    expect(deckInfo.wrapper.querySelector('.table-title-text')?.textContent).toBe('デッキ (0/15)');
+
+    deckInfo.addRow(cards[0]!);
+
+    expect(deckInfo.body.children).toHaveLength(1);
+    expect(deckInfo.findRowByNo(1)).not.toBeNull();
+  });
+
+  it('ignores duplicate DeckInfo rows so adapter item ids stay unique', () => {
+    const deckInfo = new DeckInfo();
+    deckInfo.addRow(cards[0]!, cards[0]!);
+    document.body.append(deckInfo.wrapper);
+
+    expect(deckInfo.body.children).toHaveLength(1);
+    expect(deckInfo.getCount()).toBe(1);
+
+    deckInfo.addRow(cards[0]!);
+
+    expect(deckInfo.body.children).toHaveLength(1);
+    expect(deckInfo.getCount()).toBe(1);
+  });
+});

--- a/tests/vitest/unit/components/searchCollectionView/core.spec.ts
+++ b/tests/vitest/unit/components/searchCollectionView/core.spec.ts
@@ -12,8 +12,13 @@ describe('SearchCollectionViewElement core rendering', () => {
     document.body.innerHTML = '';
   });
 
+  type NamedItem = {
+    id?: string | number;
+    name: string;
+  };
+
   it('renders item elements from plain object data and an element renderer', () => {
-    const view = new SearchCollectionViewElement();
+    const view = new SearchCollectionViewElement<NamedItem>();
     view.renderer = (item, context) => {
       const row = document.createElement('article');
       row.className = 'row';
@@ -35,7 +40,13 @@ describe('SearchCollectionViewElement core rendering', () => {
   });
 
   it('uses getItemId when item.id is absent', () => {
-    const view = new SearchCollectionViewElement<{ key: number; name: string }>();
+    interface KeyedItem {
+      id?: string | number;
+      key: number;
+      name: string;
+    }
+
+    const view = new SearchCollectionViewElement<KeyedItem>();
     view.getItemId = (item) => item.key;
     view.renderer = (item) => {
       const row = document.createElement('article');
@@ -50,7 +61,7 @@ describe('SearchCollectionViewElement core rendering', () => {
   });
 
   it('keeps previous rendered items when an item id is missing', () => {
-    const view = new SearchCollectionViewElement();
+    const view = new SearchCollectionViewElement<NamedItem>();
     const errors: CustomEvent[] = [];
     view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
     view.renderer = (item) => {
@@ -68,7 +79,7 @@ describe('SearchCollectionViewElement core rendering', () => {
   });
 
   it('keeps previous rendered items when duplicate item ids are provided', () => {
-    const view = new SearchCollectionViewElement();
+    const view = new SearchCollectionViewElement<NamedItem>();
     const errors: CustomEvent[] = [];
     view.addEventListener('component-error', (event) => errors.push(event as CustomEvent));
     view.renderer = (item) => {
@@ -212,6 +223,24 @@ describe('SearchCollectionViewElement core rendering', () => {
     expect(errors[errors.length - 1]?.detail.code).toBe('invalid-structure');
     expect(view.querySelector('li')).toBeNull();
     expect(document.body.firstElementChild).toBe(connectedRoot);
+  });
+
+  it('accepts domain item interfaces without index signatures', () => {
+    interface DomainItem {
+      id?: string | number;
+      name: string;
+    }
+
+    const view = new SearchCollectionViewElement<DomainItem>();
+    view.renderer = (item) => {
+      const row = document.createElement('article');
+      row.textContent = item.name;
+      return row;
+    };
+    view.items = [{ id: 'domain-item', name: 'Domain Item' }];
+    document.body.append(view);
+
+    expect(view.querySelector('article')?.textContent).toBe('Domain Item');
   });
 
   it('rejects custom structure roots already parented outside the returned structure', () => {
@@ -1024,7 +1053,7 @@ describe('SearchCollectionViewElement core rendering', () => {
   });
 
   it('updates selected item wrapper attributes without rerendering items', () => {
-    const view = new SearchCollectionViewElement();
+    const view = new SearchCollectionViewElement<NamedItem>();
     let renderCount = 0;
     const selectionChanges: CustomEvent[] = [];
     view.addEventListener('selection-change', (event) => selectionChanges.push(event as CustomEvent));


### PR DESCRIPTION
## Summary
- Migrates `CardList` to use `SearchCollectionViewElement` as the adapter host while preserving existing CardList toolbar, table body, row data attributes, and grid/table layout behavior.
- Synchronizes `DeckInfo` and deck loading flows through CardList/DeckInfo APIs instead of direct DOM clearing or `data-selected` mutation.
- Adds unit and PC/mobile E2E regression coverage for adapter structure, selection state, and layout switching.

## Issue
Closes #589

## Validation
- `npm run check:types`
- `npm test`
- `npm run e2e:pc`
- `npm run e2e:mobile`