### PR TITLE
CardList の検索制御を SearchCollectionView adapter に移行する

### DIFF
--- a/src/components/cardList/index.ts
+++ b/src/components/cardList/index.ts
@@ -1,5 +1,5 @@
 import mustache from 'mustache';
-import { isValidString, $dom, mesureWidth } from '@/utils';
+import { $dom, mesureWidth } from '@/utils';
 import { toInt } from '@/utils/convert';
 import { ICard, RARITY, inkCount, encodeDeckCode, availableInkCount, availableSP } from '@/models/card';
 import { createCardGrid } from '@/components/cardGrid';
@@ -9,25 +9,11 @@ import {
   type SearchCollectionStructure,
   type ViewModePlugin,
 } from '@/components/searchCollectionView';
+import { createCardListSearchModel, createCardListSearchUi, readCardListSearchState } from './searchAdapter';
 import tableHTML from './table.html.mustache?raw';
 import tableRowHTML from './row.html.mustache?raw';
 import deckInfoHTML from './deckInfoModalBody.html.mustache?raw';
 import { showShareMsg } from '../deckShare';
-
-interface IinternalSortRowInfo {
-  row: HTMLElement;
-  info: ICard;
-  gcount: number;
-}
-type sortJudgeFunc = (a: IinternalSortRowInfo, b: IinternalSortRowInfo) => number;
-
-interface IListOparationOpt {
-  name?: string;
-  maxg: number;
-  ming: number;
-  maxsp: number;
-  minsp: number;
-}
 
 export interface ICardListOption {
   search: boolean;
@@ -65,6 +51,8 @@ export class CardList {
     this.wrapper.renderer = (card) => createCardRow(card, this.srch);
     this.wrapper.selectionAttribute = { selected: '1', unselected: null };
     this.wrapper.hiddenItemClass = 'card--hidden';
+    this.wrapper.searchModel = createCardListSearchModel();
+    this.wrapper.searchUi = createCardListSearchUi(this.wrapper, this.srch);
     this.wrapper.registerViewMode(this.createCardListViewMode('grid'));
     this.wrapper.registerViewMode(this.createCardListViewMode('table'));
     this.wrapper.mode = 'grid';
@@ -78,32 +66,6 @@ export class CardList {
           button.classList.add('button-active');
           this.wrapper.mode = button.dataset['button_type']!;
         });
-      });
-
-      table.toolbarRoot.querySelector<HTMLSelectElement>('.table-sort')?.addEventListener('change', () => {
-        this.filterSortRow();
-      });
-    }
-
-    if (option.search) {
-      const form = table.toolbarRoot.querySelector('.cardlist_serch') as HTMLFormElement;
-      form.onsubmit = (e) => {
-        e.preventDefault();
-        this.filterSortRow();
-      };
-      form.querySelectorAll('.input-clear').forEach((el) =>
-        el.addEventListener('click', () => {
-          setTimeout(() => {
-            this.filterSortRow();
-          });
-        }),
-      );
-      form.querySelector('.button_search_clear')!.addEventListener('click', () => {
-        form.reset();
-        form.querySelectorAll<HTMLElement>('[data-clearable]').forEach((el) => {
-          el.dataset['clearable'] = '';
-        });
-        this.filterSortRow();
       });
     }
 
@@ -160,29 +122,7 @@ export class CardList {
   }
 
   filterSortRow() {
-    const sortVal = (this.wrapper.querySelector('.table-sort') as HTMLSelectElement).value;
-    const text = this.srch ? (this.wrapper.querySelector('.input_cardlist_serch') as HTMLInputElement).value : '';
-    const inputs = this.srch
-      ? ['min-grid', 'max-grid', 'min-sp', 'max-sp'].map((idName, idx) => {
-          const e = this.wrapper.querySelector(`#${idName}`) as HTMLInputElement;
-          return toInt(e.value, idx & 1 ? Number.MAX_SAFE_INTEGER : 0);
-        })
-      : [0, Number.MAX_SAFE_INTEGER, 0, Number.MAX_SAFE_INTEGER];
-
-    const cards = [...this.cards];
-    const infoR = generateSortRowInfo(cards.map((card) => this.findRowByNo(card.n)!).filter(Boolean));
-    if (this.srch) {
-      filerRow(infoR, {
-        name: text,
-        ming: inputs[0],
-        maxg: inputs[1],
-        minsp: inputs[2],
-        maxsp: inputs[3],
-      });
-    }
-
-    infoR.sort(getSortRow(sortVal));
-    this.body.replaceChildren(...infoR.map((info) => info.row));
+    this.wrapper.setSearchState(readCardListSearchState(this.wrapper, this.srch));
   }
 
   protected renderCards() {
@@ -357,79 +297,6 @@ export class DeckInfo extends CardList {
       .filter((n) => n > 0)
       .sort((a, b) => a - b);
     return encodeDeckCode(numbers);
-  }
-}
-
-function generateSortRowInfo(trs: HTMLElement[]): IinternalSortRowInfo[] {
-  return trs.map((row) => {
-    const info = getCardRowInfo(row);
-    const gcount = toInt(row.querySelector('.card_gridcount')!.textContent?.trim());
-    return { row, info, gcount };
-  });
-}
-
-function filerRow(trs: IinternalSortRowInfo[], opt: IListOparationOpt) {
-  const filterCondition = (info: IinternalSortRowInfo) => {
-    if (isValidString(opt.name) && !info.info.ja.includes(opt.name)) return false;
-    if (info.gcount > opt.maxg || info.gcount < opt.ming) return false;
-    if (info.info.sp > opt.maxsp || info.info.sp < opt.minsp) return false;
-    return true;
-  };
-  return trs.map<IinternalSortRowInfo>((t) => {
-    if (filterCondition(t)) {
-      t.row.classList.remove('card--hidden');
-    } else {
-      t.row.classList.add('card--hidden');
-    }
-    return t;
-  });
-}
-
-const noAsc: sortJudgeFunc = (a, b) => a.info.n - b.info.n;
-const gJudge: sortJudgeFunc = (a, b) => a.gcount - b.gcount;
-const spJudge: sortJudgeFunc = (a, b) => a.info.sp - b.info.sp;
-const rarityJudge: sortJudgeFunc = (a, b) => a.info.r - b.info.r;
-
-const gcountAsc: sortJudgeFunc = (a, b) => {
-  let inf = gJudge(a, b);
-  if (inf != 0) return inf;
-  inf = spJudge(a, b);
-  if (inf != 0) return inf;
-  return noAsc(a, b);
-};
-
-const spAsc: sortJudgeFunc = (a, b) => {
-  let inf = spJudge(a, b);
-  if (inf != 0) return inf;
-  inf = gJudge(a, b);
-  if (inf != 0) return inf;
-  return noAsc(a, b);
-};
-
-const rarityAsc: sortJudgeFunc = (a, b) => {
-  const inf = rarityJudge(a, b);
-  if (inf != 0) return inf;
-  return gcountAsc(a, b);
-};
-
-function getSortRow(orderType: string): sortJudgeFunc {
-  switch (orderType) {
-    case '1':
-      return (a, b) => noAsc(b, a);
-    case '2':
-      return gcountAsc;
-    case '3':
-      return (a, b) => gcountAsc(b, a);
-    case '4':
-      return spAsc;
-    case '5':
-      return (a, b) => spAsc(b, a);
-    case '6':
-      return rarityAsc;
-    case '7':
-      return (a, b) => rarityAsc(b, a);
-    default:
-      return noAsc;
   }
 }
 

--- a/src/components/cardList/searchAdapter.ts
+++ b/src/components/cardList/searchAdapter.ts
@@ -1,6 +1,6 @@
 import { isValidString } from '@/utils';
 import { inkCount, type ICard } from '@/models/card';
-import type { SearchModelPlugin, SearchState } from '@/components/searchCollectionView';
+import type { SearchCollectionItem, SearchModelPlugin, SearchState } from '@/components/searchCollectionView';
 
 export interface CardListSearchFilters {
   minGrid: number;
@@ -14,6 +14,8 @@ export type CardListSearchState = SearchState & {
   sort?: string;
   filters?: CardListSearchFilters;
 };
+
+export type CardListSearchItem = ICard & SearchCollectionItem;
 
 const DEFAULT_FILTERS: CardListSearchFilters = {
   minGrid: 0,
@@ -30,7 +32,7 @@ export function createDefaultCardListSearchState(sort = '0'): CardListSearchStat
   };
 }
 
-export function createCardListSearchModel(): SearchModelPlugin<ICard> {
+export function createCardListSearchModel(): SearchModelPlugin<CardListSearchItem> {
   return {
     initialState: createDefaultCardListSearchState(),
     match(card, state) {

--- a/src/components/cardList/searchAdapter.ts
+++ b/src/components/cardList/searchAdapter.ts
@@ -76,16 +76,15 @@ export function createCardListSearchUi(
   view: SearchCollectionViewElement<CardListSearchItem>,
   searchEnabled: boolean,
 ): SearchUiPlugin<CardListSearchItem> {
-  let controller: AbortController | null = null;
+  let cleanup: (() => void) | null = null;
   return {
     render(context) {
-      controller?.abort();
+      cleanup?.();
       const root = document.createElement('span');
       root.className = 'cardlist-search-adapter';
       root.hidden = true;
 
       const nextController = new AbortController();
-      controller = nextController;
       const syncState = () => context.setState(readCardListSearchState(view, searchEnabled));
 
       view.querySelector<HTMLSelectElement>('.table-sort')?.addEventListener('change', syncState, {
@@ -93,14 +92,14 @@ export function createCardListSearchUi(
       });
 
       const form = view.querySelector<HTMLFormElement>('.cardlist_serch');
-      form?.addEventListener(
-        'submit',
-        (event) => {
-          event.preventDefault();
-          syncState();
-        },
-        { signal: nextController.signal },
-      );
+      const previousOnSubmit = form?.onsubmit ?? null;
+      const handleSubmit = (event: SubmitEvent) => {
+        event.preventDefault();
+        syncState();
+        return false;
+      };
+      if (form) form.onsubmit = handleSubmit;
+      form?.addEventListener('submit', handleSubmit, { signal: nextController.signal });
 
       form?.querySelectorAll('.input-clear').forEach((el) =>
         el.addEventListener(
@@ -123,14 +122,20 @@ export function createCardListSearchUi(
         },
         { signal: nextController.signal },
       );
+      cleanup = () => {
+        nextController.abort();
+        if (form?.onsubmit === handleSubmit) {
+          form.onsubmit = previousOnSubmit;
+        }
+        cleanup = null;
+      };
       return root;
     },
     update() {
       // Visible controls live in CardList; keep this sentinel stable.
     },
     destroy() {
-      controller?.abort();
-      controller = null;
+      cleanup?.();
     },
   };
 }

--- a/src/components/cardList/searchAdapter.ts
+++ b/src/components/cardList/searchAdapter.ts
@@ -1,0 +1,129 @@
+import { isValidString } from '@/utils';
+import { inkCount, type ICard } from '@/models/card';
+import type { SearchModelPlugin, SearchState } from '@/components/searchCollectionView';
+
+export interface CardListSearchFilters {
+  minGrid: number;
+  maxGrid: number;
+  minSp: number;
+  maxSp: number;
+}
+
+export type CardListSearchState = SearchState & {
+  query?: string;
+  sort?: string;
+  filters?: CardListSearchFilters;
+};
+
+const DEFAULT_FILTERS: CardListSearchFilters = {
+  minGrid: 0,
+  maxGrid: Number.MAX_SAFE_INTEGER,
+  minSp: 0,
+  maxSp: Number.MAX_SAFE_INTEGER,
+};
+
+export function createDefaultCardListSearchState(sort = '0'): CardListSearchState {
+  return {
+    query: '',
+    sort,
+    filters: { ...DEFAULT_FILTERS },
+  };
+}
+
+export function createCardListSearchModel(): SearchModelPlugin<ICard> {
+  return {
+    initialState: createDefaultCardListSearchState(),
+    match(card, state) {
+      const cardState = normalizeCardListSearchState(state);
+      if (!matchesCardListQuery(card, cardState)) return false;
+      if (!matchesCardListFilters(card, cardState.filters)) return false;
+      return true;
+    },
+    compare(a, b, state) {
+      const cardState = normalizeCardListSearchState(state);
+      const aMatches = matchesCardListQuery(a, cardState);
+      const bMatches = matchesCardListQuery(b, cardState);
+
+      if (aMatches !== bMatches) return aMatches ? -1 : 1;
+      if (!aMatches && !bMatches) return noAsc(a, b);
+      return compareCardsBySort(a, b, cardState.sort);
+    },
+  };
+}
+
+function matchesCardListQuery(card: ICard, state: Required<CardListSearchState>) {
+  return !isValidString(state.query) || card.ja.includes(state.query);
+}
+
+function matchesCardListFilters(card: ICard, filters: CardListSearchFilters) {
+  const gridCount = inkCount(card.g, card.sg);
+  if (gridCount < filters.minGrid || gridCount > filters.maxGrid) return false;
+  if (card.sp < filters.minSp || card.sp > filters.maxSp) return false;
+  return true;
+}
+
+export function normalizeCardListSearchState(state: SearchState): Required<CardListSearchState> {
+  const filters = state.filters ?? {};
+  return {
+    query: state.query ?? '',
+    sort: state.sort ?? '0',
+    filters: {
+      minGrid: toFiniteNumber(filters.minGrid, DEFAULT_FILTERS.minGrid),
+      maxGrid: toFiniteNumber(filters.maxGrid, DEFAULT_FILTERS.maxGrid),
+      minSp: toFiniteNumber(filters.minSp, DEFAULT_FILTERS.minSp),
+      maxSp: toFiniteNumber(filters.maxSp, DEFAULT_FILTERS.maxSp),
+    },
+  };
+}
+
+function toFiniteNumber(value: unknown, fallback: number) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function compareCardsBySort(a: ICard, b: ICard, sort: string) {
+  switch (sort) {
+    case '1':
+      return noAsc(b, a);
+    case '2':
+      return gcountAsc(a, b);
+    case '3':
+      return gcountAsc(b, a);
+    case '4':
+      return spAsc(a, b);
+    case '5':
+      return spAsc(b, a);
+    case '6':
+      return rarityAsc(a, b);
+    case '7':
+      return rarityAsc(b, a);
+    default:
+      return noAsc(a, b);
+  }
+}
+
+const noAsc = (a: ICard, b: ICard) => a.n - b.n;
+const gJudge = (a: ICard, b: ICard) => inkCount(a.g, a.sg) - inkCount(b.g, b.sg);
+const spJudge = (a: ICard, b: ICard) => a.sp - b.sp;
+const rarityJudge = (a: ICard, b: ICard) => a.r - b.r;
+
+function gcountAsc(a: ICard, b: ICard) {
+  const gridCompared = gJudge(a, b);
+  if (gridCompared !== 0) return gridCompared;
+  const spCompared = spJudge(a, b);
+  if (spCompared !== 0) return spCompared;
+  return noAsc(a, b);
+}
+
+function spAsc(a: ICard, b: ICard) {
+  const spCompared = spJudge(a, b);
+  if (spCompared !== 0) return spCompared;
+  const gridCompared = gJudge(a, b);
+  if (gridCompared !== 0) return gridCompared;
+  return noAsc(a, b);
+}
+
+function rarityAsc(a: ICard, b: ICard) {
+  const rarityCompared = rarityJudge(a, b);
+  if (rarityCompared !== 0) return rarityCompared;
+  return gcountAsc(a, b);
+}

--- a/src/components/cardList/searchAdapter.ts
+++ b/src/components/cardList/searchAdapter.ts
@@ -1,6 +1,13 @@
 import { isValidString } from '@/utils';
+import { toInt } from '@/utils/convert';
 import { inkCount, type ICard } from '@/models/card';
-import type { SearchCollectionItem, SearchModelPlugin, SearchState } from '@/components/searchCollectionView';
+import {
+  SearchCollectionViewElement,
+  type SearchCollectionItem,
+  type SearchModelPlugin,
+  type SearchState,
+  type SearchUiPlugin,
+} from '@/components/searchCollectionView';
 
 export interface CardListSearchFilters {
   minGrid: number;
@@ -43,6 +50,86 @@ export function createCardListSearchModel(): SearchModelPlugin<CardListSearchIte
     },
     compare(a, b, state) {
       return compareCardsBySort(a, b, normalizeCardListSearchState(state).sort);
+    },
+  };
+}
+
+export function readCardListSearchState(root: ParentNode, searchEnabled: boolean): CardListSearchState {
+  const sort = root.querySelector<HTMLSelectElement>('.table-sort')?.value ?? '0';
+  if (!searchEnabled) {
+    return createDefaultCardListSearchState(sort);
+  }
+
+  return {
+    query: root.querySelector<HTMLInputElement>('.input_cardlist_serch')?.value ?? '',
+    sort,
+    filters: {
+      minGrid: toInt(root.querySelector<HTMLInputElement>('#min-grid')?.value, 0),
+      maxGrid: toInt(root.querySelector<HTMLInputElement>('#max-grid')?.value, Number.MAX_SAFE_INTEGER),
+      minSp: toInt(root.querySelector<HTMLInputElement>('#min-sp')?.value, 0),
+      maxSp: toInt(root.querySelector<HTMLInputElement>('#max-sp')?.value, Number.MAX_SAFE_INTEGER),
+    },
+  };
+}
+
+export function createCardListSearchUi(
+  view: SearchCollectionViewElement<CardListSearchItem>,
+  searchEnabled: boolean,
+): SearchUiPlugin<CardListSearchItem> {
+  let controller: AbortController | null = null;
+  return {
+    render(context) {
+      const root = document.createElement('span');
+      root.className = 'cardlist-search-adapter';
+      root.hidden = true;
+
+      const nextController = new AbortController();
+      controller = nextController;
+      const syncState = () => context.setState(readCardListSearchState(view, searchEnabled));
+
+      view.querySelector<HTMLSelectElement>('.table-sort')?.addEventListener('change', syncState, {
+        signal: nextController.signal,
+      });
+
+      const form = view.querySelector<HTMLFormElement>('.cardlist_serch');
+      form?.addEventListener(
+        'submit',
+        (event) => {
+          event.preventDefault();
+          syncState();
+        },
+        { signal: nextController.signal },
+      );
+
+      form?.querySelectorAll('.input-clear').forEach((el) =>
+        el.addEventListener(
+          'click',
+          () => {
+            setTimeout(syncState);
+          },
+          { signal: nextController.signal },
+        ),
+      );
+
+      form?.querySelector('.button_search_clear')?.addEventListener(
+        'click',
+        () => {
+          form.reset();
+          form.querySelectorAll<HTMLElement>('[data-clearable]').forEach((el) => {
+            el.dataset['clearable'] = '';
+          });
+          syncState();
+        },
+        { signal: nextController.signal },
+      );
+      return root;
+    },
+    update() {
+      // Visible controls live in CardList; keep this sentinel stable.
+    },
+    destroy() {
+      controller?.abort();
+      controller = null;
     },
   };
 }

--- a/src/components/cardList/searchAdapter.ts
+++ b/src/components/cardList/searchAdapter.ts
@@ -79,6 +79,7 @@ export function createCardListSearchUi(
   let controller: AbortController | null = null;
   return {
     render(context) {
+      controller?.abort();
       const root = document.createElement('span');
       root.className = 'cardlist-search-adapter';
       root.hidden = true;

--- a/src/components/cardList/searchAdapter.ts
+++ b/src/components/cardList/searchAdapter.ts
@@ -40,13 +40,7 @@ export function createCardListSearchModel(): SearchModelPlugin<ICard> {
       return true;
     },
     compare(a, b, state) {
-      const cardState = normalizeCardListSearchState(state);
-      const aMatches = matchesCardListQuery(a, cardState);
-      const bMatches = matchesCardListQuery(b, cardState);
-
-      if (aMatches !== bMatches) return aMatches ? -1 : 1;
-      if (!aMatches && !bMatches) return noAsc(a, b);
-      return compareCardsBySort(a, b, cardState.sort);
+      return compareCardsBySort(a, b, normalizeCardListSearchState(state).sort);
     },
   };
 }

--- a/tests/e2e/test/mobile/cardList.spec.ts
+++ b/tests/e2e/test/mobile/cardList.spec.ts
@@ -64,3 +64,47 @@ test('preserves card row identity and selected display while switching layouts o
   expect(await card.evaluate((node, previous) => node === previous, cardHandle)).toBe(true);
   await expect(card).toHaveAttribute('data-selected', '1');
 });
+
+test('searches filters sorts and clears card list through preserved controls on mobile', async ({ page, cardUtil }) => {
+  await page.goto('/');
+  await cardUtil.showCardList();
+
+  const list = page.locator('.card-list-container');
+  const visibleRows = list.locator('li.cardlist_table_row:not(.card--hidden)');
+
+  await list.locator('.input_cardlist_serch').fill('シューター');
+  await list.locator('#min-grid').fill('6');
+  await list.locator('#max-grid').fill('12');
+  await list.locator('#min-sp').fill('2');
+  await list.locator('#max-sp').fill('4');
+  await list.locator('.table-sort').selectOption('5');
+  await list.locator('.cardlist_serch').evaluate((form) => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  });
+
+  await expect(visibleRows.first()).toContainText('シューター');
+  await expect(list.locator('li.cardlist_table_row.card--hidden').first()).toHaveAttribute('data-hidden', 'true');
+
+  const firstSp = Number((await visibleRows.first().locator('.card_sp').innerText()).trim());
+  const secondSp = Number((await visibleRows.nth(1).locator('.card_sp').innerText()).trim());
+  expect(firstSp).toBeGreaterThanOrEqual(secondSp);
+
+  for (const row of await visibleRows.evaluateAll((nodes) =>
+    nodes.slice(0, 5).map((node) => ({
+      grid: Number(node.querySelector('.card_gridcount')?.textContent?.trim() ?? '0'),
+      sp: Number(node.querySelector('.card_sp')?.textContent?.trim() ?? '0'),
+      text: node.textContent ?? '',
+    })),
+  )) {
+    expect(row.text).toContain('シューター');
+    expect(row.grid).toBeGreaterThanOrEqual(6);
+    expect(row.grid).toBeLessThanOrEqual(12);
+    expect(row.sp).toBeGreaterThanOrEqual(2);
+    expect(row.sp).toBeLessThanOrEqual(4);
+  }
+
+  await list.locator('.button_search_clear').evaluate((button) => {
+    (button as HTMLButtonElement).click();
+  });
+  await expect(list.locator('li.cardlist_table_row.card--hidden')).toHaveCount(0);
+});

--- a/tests/e2e/test/pc/cardList.spec.ts
+++ b/tests/e2e/test/pc/cardList.spec.ts
@@ -60,3 +60,44 @@ test('preserves card row identity and selected display while switching layouts',
   expect(await card.evaluate((node, previous) => node === previous, cardHandle)).toBe(true);
   await expect(card).toHaveAttribute('data-selected', '1');
 });
+
+test('searches filters sorts and clears card list through preserved controls', async ({ page }) => {
+  await page.goto('/');
+
+  const list = page.locator('.card-list-container');
+  const visibleRows = list.locator('li.cardlist_table_row:not(.card--hidden)');
+
+  await list.locator('.input_cardlist_serch').fill('シューター');
+  await list.locator('#min-grid').fill('6');
+  await list.locator('#max-grid').fill('12');
+  await list.locator('#min-sp').fill('2');
+  await list.locator('#max-sp').fill('4');
+  await list.locator('.table-sort').selectOption('5');
+  await list.locator('.cardlist_serch').evaluate((form) => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  });
+
+  await expect(visibleRows.first()).toContainText('シューター');
+  await expect(list.locator('li.cardlist_table_row.card--hidden').first()).toHaveAttribute('data-hidden', 'true');
+
+  const firstSp = Number((await visibleRows.first().locator('.card_sp').innerText()).trim());
+  const secondSp = Number((await visibleRows.nth(1).locator('.card_sp').innerText()).trim());
+  expect(firstSp).toBeGreaterThanOrEqual(secondSp);
+
+  for (const row of await visibleRows.evaluateAll((nodes) =>
+    nodes.slice(0, 5).map((node) => ({
+      grid: Number(node.querySelector('.card_gridcount')?.textContent?.trim() ?? '0'),
+      sp: Number(node.querySelector('.card_sp')?.textContent?.trim() ?? '0'),
+      text: node.textContent ?? '',
+    })),
+  )) {
+    expect(row.text).toContain('シューター');
+    expect(row.grid).toBeGreaterThanOrEqual(6);
+    expect(row.grid).toBeLessThanOrEqual(12);
+    expect(row.sp).toBeGreaterThanOrEqual(2);
+    expect(row.sp).toBeLessThanOrEqual(4);
+  }
+
+  await list.locator('.button_search_clear').click();
+  await expect(list.locator('li.cardlist_table_row.card--hidden')).toHaveCount(0);
+});

--- a/tests/e2e/test/pc/cardList.spec.ts
+++ b/tests/e2e/test/pc/cardList.spec.ts
@@ -98,6 +98,8 @@ test('searches filters sorts and clears card list through preserved controls', a
     expect(row.sp).toBeLessThanOrEqual(4);
   }
 
-  await list.locator('.button_search_clear').click();
+  await list.locator('.button_search_clear').evaluate((button) => {
+    (button as HTMLButtonElement).click();
+  });
   await expect(list.locator('li.cardlist_table_row.card--hidden')).toHaveCount(0);
 });

--- a/tests/vitest/unit/components/cardList/adapter.spec.ts
+++ b/tests/vitest/unit/components/cardList/adapter.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { CardList, DeckInfo, getCardRowInfo } from '@/components/cardList';
-import { createCardListSearchModel } from '@/components/cardList/searchAdapter';
+import { createCardListSearchModel, createCardListSearchUi } from '@/components/cardList/searchAdapter';
 import type { ICard } from '@/models/card';
 
 const cards: ICard[] = [
@@ -169,5 +169,75 @@ describe('CardList SearchCollectionView adapter', () => {
     expect(rows.map((row) => row.hidden)).toEqual([true, false, false]);
     expect(rows.map((row) => row.dataset.hidden)).toEqual(['true', 'false', 'false']);
     expect(rows.map((row) => row.classList.contains('card--hidden'))).toEqual([true, false, false]);
+  });
+
+  it('drives SearchCollectionView search state from the preserved CardList toolbar controls', () => {
+    const cardList = new CardList({ search: true, title: 'カードリスト' });
+    document.body.append(cardList.wrapper);
+    const states: unknown[] = [];
+    cardList.wrapper.addEventListener('search-state-change', (event) => {
+      states.push((event as CustomEvent).detail.state);
+    });
+    cardList.wrapper.searchModel = createCardListSearchModel();
+    cardList.wrapper.searchUi = createCardListSearchUi(cardList.wrapper, true);
+
+    const searchInput = cardList.wrapper.querySelector<HTMLInputElement>('.input_cardlist_serch')!;
+    const minGrid = cardList.wrapper.querySelector<HTMLInputElement>('#min-grid')!;
+    const maxGrid = cardList.wrapper.querySelector<HTMLInputElement>('#max-grid')!;
+    const minSp = cardList.wrapper.querySelector<HTMLInputElement>('#min-sp')!;
+    const maxSp = cardList.wrapper.querySelector<HTMLInputElement>('#max-sp')!;
+    const sort = cardList.wrapper.querySelector<HTMLSelectElement>('.table-sort')!;
+    const form = cardList.wrapper.querySelector<HTMLFormElement>('.cardlist_serch')!;
+
+    searchInput.value = 'Shooter';
+    minGrid.value = '2';
+    maxGrid.value = '8';
+    minSp.value = '1';
+    maxSp.value = '4';
+    sort.value = '5';
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    const lastState = states[states.length - 1];
+    expect(lastState).toEqual({
+      query: 'Shooter',
+      sort: '5',
+      filters: {
+        minGrid: 2,
+        maxGrid: 8,
+        minSp: 1,
+        maxSp: 4,
+      },
+    });
+
+    cardList.wrapper.querySelector<HTMLButtonElement>('.button_search_clear')!.click();
+
+    expect(searchInput.value).toBe('');
+    expect(minGrid.value).toBe('');
+    expect(maxGrid.value).toBe('');
+    expect(minSp.value).toBe('');
+    expect(maxSp.value).toBe('');
+    expect(states[states.length - 1]).toEqual({
+      query: '',
+      sort: '5',
+      filters: {
+        minGrid: 0,
+        maxGrid: Number.MAX_SAFE_INTEGER,
+        minSp: 0,
+        maxSp: Number.MAX_SAFE_INTEGER,
+      },
+    });
+  });
+
+  it('keeps the hidden CardList search UI sentinel stable across search state updates', () => {
+    const cardList = new CardList({ search: true, title: 'カードリスト' });
+    document.body.append(cardList.wrapper);
+    cardList.wrapper.searchModel = createCardListSearchModel();
+    cardList.wrapper.searchUi = createCardListSearchUi(cardList.wrapper, true);
+
+    const sentinel = cardList.wrapper.querySelector('.cardlist-search-adapter');
+    cardList.wrapper.setSearchState({ query: 'Shooter' });
+    cardList.wrapper.setSearchState({ query: 'Roller' });
+
+    expect(cardList.wrapper.querySelector('.cardlist-search-adapter')).toBe(sentinel);
   });
 });

--- a/tests/vitest/unit/components/cardList/adapter.spec.ts
+++ b/tests/vitest/unit/components/cardList/adapter.spec.ts
@@ -165,9 +165,9 @@ describe('CardList SearchCollectionView adapter', () => {
     });
 
     const rows = [...cardList.body.querySelectorAll<HTMLElement>('li.cardlist_table_row')];
-    expect(rows.map((row) => row.dataset.card_no)).toEqual(['30', '10', '20']);
-    expect(rows.map((row) => row.hidden)).toEqual([false, false, true]);
-    expect(rows.map((row) => row.dataset.hidden)).toEqual(['false', 'false', 'true']);
-    expect(rows.map((row) => row.classList.contains('card--hidden'))).toEqual([false, false, true]);
+    expect(rows.map((row) => row.dataset.card_no)).toEqual(['20', '30', '10']);
+    expect(rows.map((row) => row.hidden)).toEqual([true, false, false]);
+    expect(rows.map((row) => row.dataset.hidden)).toEqual(['true', 'false', 'false']);
+    expect(rows.map((row) => row.classList.contains('card--hidden'))).toEqual([true, false, false]);
   });
 });

--- a/tests/vitest/unit/components/cardList/adapter.spec.ts
+++ b/tests/vitest/unit/components/cardList/adapter.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { CardList, DeckInfo, getCardRowInfo } from '@/components/cardList';
+import { createCardListSearchModel } from '@/components/cardList/searchAdapter';
 import type { ICard } from '@/models/card';
 
 const cards: ICard[] = [
@@ -136,5 +137,37 @@ describe('CardList SearchCollectionView adapter', () => {
 
     expect(deckInfo.body.children).toHaveLength(1);
     expect(deckInfo.getCount()).toBe(1);
+  });
+
+  it('filters and sorts CardList rows from item data instead of rendered DOM text', () => {
+    const cardList = new CardList({ search: true, title: 'カードリスト' });
+    cardList.wrapper.searchModel = createCardListSearchModel();
+    cardList.addRow(
+      { n: 10, r: 1, sp: 5, ja: 'Short Shooter', g: '1', sg: '' },
+      { n: 20, r: 0, sp: 1, ja: 'Long Charger', g: '1111', sg: '' },
+      { n: 30, r: 2, sp: 3, ja: 'Short Roller', g: '11', sg: '' },
+    );
+    document.body.append(cardList.wrapper);
+
+    cardList.findRowByNo(10)!.querySelector<HTMLElement>('.card_name')!.textContent = 'DOM Mismatch';
+    cardList.findRowByNo(20)!.querySelector<HTMLElement>('.card_name')!.textContent = 'Short DOM Only';
+    cardList.findRowByNo(30)!.querySelector<HTMLElement>('.card_sp')!.textContent = '99';
+
+    cardList.wrapper.setSearchState({
+      query: 'Short',
+      sort: '4',
+      filters: {
+        minGrid: 0,
+        maxGrid: 2,
+        minSp: 0,
+        maxSp: Number.MAX_SAFE_INTEGER,
+      },
+    });
+
+    const rows = [...cardList.body.querySelectorAll<HTMLElement>('li.cardlist_table_row')];
+    expect(rows.map((row) => row.dataset.card_no)).toEqual(['30', '10', '20']);
+    expect(rows.map((row) => row.hidden)).toEqual([false, false, true]);
+    expect(rows.map((row) => row.dataset.hidden)).toEqual(['false', 'false', 'true']);
+    expect(rows.map((row) => row.classList.contains('card--hidden'))).toEqual([false, false, true]);
   });
 });

--- a/tests/vitest/unit/components/cardList/adapter.spec.ts
+++ b/tests/vitest/unit/components/cardList/adapter.spec.ts
@@ -240,4 +240,27 @@ describe('CardList SearchCollectionView adapter', () => {
 
     expect(cardList.wrapper.querySelector('.cardlist-search-adapter')).toBe(sentinel);
   });
+
+  it('syncs state through the form onsubmit hook used by the shared input clear handler', () => {
+    const cardList = new CardList({ search: true, title: 'カードリスト' });
+    document.body.append(cardList.wrapper);
+    const states: unknown[] = [];
+    cardList.wrapper.addEventListener('search-state-change', (event) => {
+      states.push((event as CustomEvent).detail.state);
+    });
+    cardList.wrapper.searchModel = createCardListSearchModel();
+    cardList.wrapper.searchUi = createCardListSearchUi(cardList.wrapper, true);
+
+    const searchInput = cardList.wrapper.querySelector<HTMLInputElement>('.input_cardlist_serch')!;
+    const form = cardList.wrapper.querySelector<HTMLFormElement>('.cardlist_serch')!;
+
+    searchInput.value = 'Shooter';
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    expect(states[states.length - 1]).toMatchObject({ query: 'Shooter' });
+
+    searchInput.value = '';
+    form.onsubmit?.(new SubmitEvent('submit'));
+
+    expect(states[states.length - 1]).toMatchObject({ query: '' });
+  });
 });


### PR DESCRIPTION
## Summary
- CardList の検索・絞り込み・ソートを `SearchCollectionView` の search model / search UI adapter に移行
- DOM テキスト依存のフィルタリングを item data ベースに変更し、`hidden` / `data-hidden` / `.card--hidden` の同期を維持
- PC / mobile の e2e に検索・範囲フィルタ・ソート・クリアのカバレッジを追加

## Testing
- `npm run check:types`
- `npm test -- --run`
- `npm run e2e:pc`
- `npm run e2e:mobile`


closes #595