### PR TITLE
Connect deck editor to SearchCollectionView item-action events

### DIFF
--- a/src/core/deckEditor/index.ts
+++ b/src/core/deckEditor/index.ts
@@ -1,5 +1,5 @@
-import { CardList, DeckInfo, getCardRowInfo } from '@/components/cardList';
-import { getCardList, decodeDeckCode } from '@/models/card';
+import { CardList, DeckInfo } from '@/components/cardList';
+import { type ICard, getCardList, decodeDeckCode } from '@/models/card';
 import { $dom } from '@/utils';
 import { toInt } from '@/utils/convert';
 import * as dialog from '@/components/dialog';
@@ -38,45 +38,43 @@ deckEditManager.showCount = () => {
 function loadDeck(code: string | null | undefined, id?: string) {
   const cardInfo = decodeDeckCode(code);
   deckEditManager.clearRows();
-  cardListManager.setSelectedCardNos(cardInfo.map((info) => info.n));
   deckEditManager.addRow(...cardInfo);
+  cardListManager.setSelectedCardNos(cardInfo.map((info) => info.n));
   deckEditManager.body.dataset['id'] = id;
 }
 
-{
-  const rowClassName = 'cardlist_table_row';
-  // カードクリック
-  cardListManager.body.addEventListener('click', (e) => {
-    if (!e.target) return;
-    const el = e.target as HTMLElement;
-    window.setTimeout(() => {
-      if (el.closest('.button-add')) {
-        const row = el.closest<HTMLElement>('.' + rowClassName)!;
-        const info = getCardRowInfo(row);
-        deckEditManager.addRow(info);
-        cardListManager.setCardSelected(info.n, true);
-      } else if (el.closest('.button-delete')) {
-        const row = el.closest<HTMLElement>('.' + rowClassName)!;
-        const no = toInt(row.dataset['card_no']);
-        deckEditManager.removeRowByNo(no);
-        cardListManager.setCardSelected(no, false);
-      }
-    });
-  });
-  deckEditManager.body.addEventListener('click', (e) => {
-    if (!e.target) return;
-    const el = e.target as HTMLElement;
-    window.setTimeout(() => {
-      if (el.closest('.button-delete')) {
-        const row = el.closest<HTMLElement>('.' + rowClassName)!;
-        const no = toInt(row.dataset['card_no']);
-        const r = cardListManager.findRowByNo(no);
-        if (r) cardListManager.setCardSelected(no, false);
-        deckEditManager.removeRow(row);
-      }
-    });
-  });
+function addCardToDeck(info: ICard) {
+  deckEditManager.addRow(info);
+  cardListManager.setCardSelected(info.n, true);
 }
+
+function removeCardFromDeck(cardNo: number) {
+  deckEditManager.removeRowByNo(cardNo);
+  cardListManager.setCardSelected(cardNo, false);
+}
+
+function removeDeckRow(row: HTMLElement) {
+  const no = toInt(row.dataset['card_no']);
+  deckEditManager.removeRow(row);
+  cardListManager.setCardSelected(no, false);
+}
+
+cardListManager.wrapper.addEventListener('item-action', (event) => {
+  const { action, item, itemId } = (event as CustomEvent).detail;
+  if (action === 'add') {
+    addCardToDeck(item as ICard);
+  } else if (action === 'delete') {
+    removeCardFromDeck(toInt(itemId));
+  }
+});
+
+deckEditManager.wrapper.addEventListener('item-action', (event) => {
+  const { action, itemId } = (event as CustomEvent).detail;
+  if (action !== 'delete') return;
+
+  const row = deckEditManager.findRowByNo(toInt(itemId));
+  if (row) removeDeckRow(row);
+});
 
 {
   // タブ切り替え

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -3,7 +3,7 @@ import { decodeDeckCode } from '@/models/card';
 export function loadDeck(code: string | null | undefined, id?: string) {
   const cardInfo = decodeDeckCode(code);
   window.DeckEditManager.clearRows();
-  window.CardListManager.setSelectedCardNos(cardInfo.map((info) => info.n));
   window.DeckEditManager.addRow(...cardInfo);
+  window.CardListManager.setSelectedCardNos(cardInfo.map((info) => info.n));
   window.DeckEditManager.body.dataset['id'] = id;
 }

--- a/tests/e2e/test/mobile/cardList.spec.ts
+++ b/tests/e2e/test/mobile/cardList.spec.ts
@@ -20,6 +20,11 @@ test('select card and clear', async ({ page, cardUtil }) => {
   await page.locator('button').filter({ hasText: 'Close modal' }).click();
   await page.locator('li').filter({ hasText: 'カードリスト' }).click();
   await cardUtil.clearAll();
+  await cardUtil.showCardList();
+  await expect(cardUtil.getCardByIdFromList(1)).not.toHaveAttribute('data-selected', '1');
+  await expect(cardUtil.getCardByIdFromList(2)).not.toHaveAttribute('data-selected', '1');
+  await expect(cardUtil.getCardByIdFromList(3)).not.toHaveAttribute('data-selected', '1');
+  await expect(cardUtil.getCardByIdFromList(4)).not.toHaveAttribute('data-selected', '1');
   await expect(page.getByText('カードリスト デッキ (0/15)')).toBeInViewport();
 
   // add and delete

--- a/tests/e2e/test/pc/cardList.spec.ts
+++ b/tests/e2e/test/pc/cardList.spec.ts
@@ -19,6 +19,10 @@ test('select card and clear', async ({ page, cardUtil }) => {
   await expect(page.getByText('デッキ内容のクリア Close modal')).toBeInViewport();
   await page.locator('button').filter({ hasText: 'Close modal' }).click();
   await cardUtil.clearAll();
+  await expect(cardUtil.getCardByIdFromList(1)).not.toHaveAttribute('data-selected', '1');
+  await expect(cardUtil.getCardByIdFromList(2)).not.toHaveAttribute('data-selected', '1');
+  await expect(cardUtil.getCardByIdFromList(3)).not.toHaveAttribute('data-selected', '1');
+  await expect(cardUtil.getCardByIdFromList(4)).not.toHaveAttribute('data-selected', '1');
   await expect(page.locator('.table-title-text').nth(1)).toHaveText('デッキ (0/15)');
 
   // add and delete

--- a/tests/vitest/unit/components/cardList/adapter.spec.ts
+++ b/tests/vitest/unit/components/cardList/adapter.spec.ts
@@ -82,6 +82,38 @@ describe('CardList SearchCollectionView adapter', () => {
     expect(cardList.findRowByNo(2)?.getAttribute('data-selected')).toBe('1');
   });
 
+  it('emits card list add and delete actions with card data through SearchCollectionView', () => {
+    const cardList = new CardList({ search: true, title: 'カードリスト' });
+    cardList.addRow(...cards);
+    document.body.append(cardList.wrapper);
+    const actions: CustomEvent[] = [];
+    cardList.wrapper.addEventListener('item-action', (event) => actions.push(event as CustomEvent));
+
+    cardList.findRowByNo(2)!.querySelector<HTMLButtonElement>('.button-add')!.click();
+    cardList.findRowByNo(2)!.querySelector<HTMLButtonElement>('.button-delete')!.click();
+
+    expect(actions.map((event) => event.detail.action)).toEqual(['add', 'delete']);
+    expect(actions.map((event) => event.detail.itemId)).toEqual(['2', '2']);
+    expect(actions[0]?.detail.item).toMatchObject(cards[1]!);
+  });
+
+  it('emits deck delete actions with card data through SearchCollectionView', () => {
+    const deckInfo = new DeckInfo();
+    deckInfo.addRow(...cards);
+    document.body.append(deckInfo.wrapper);
+    const actions: CustomEvent[] = [];
+    deckInfo.wrapper.addEventListener('item-action', (event) => actions.push(event as CustomEvent));
+
+    deckInfo.findRowByNo(1)!.querySelector<HTMLButtonElement>('.button-delete')!.click();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.detail).toMatchObject({
+      action: 'delete',
+      itemId: '1',
+      item: cards[0],
+    });
+  });
+
   it('keeps DeckInfo item state synchronized when rows are removed by element', () => {
     const deckInfo = new DeckInfo();
     deckInfo.addRow(...cards);


### PR DESCRIPTION
## Summary
- Switched deck editor add/delete handling from direct row click delegation to `SearchCollectionView` `item-action` events.
- Kept deck load/clear selection state synchronized between the deck editor and card list.
- Added regression coverage for adapter event payloads and PC/mobile selection behavior.
- Recorded the implementation plan in `docs/superpowers/plans/2026-05-03-deck-editor-search-collection-events.md`.

## Testing
- `npm run check:types` passed.
- `npm test` passed.
- `npm run e2e:pc` passed.
- `npm run e2e:mobile` passed.


---

closes #590
